### PR TITLE
fix: update integrations redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,5 +19,5 @@
 
 [[redirects]]
   from = "/integrations"
-  to = "/#platforms"
+  to = "/#integrations"
   status = 301


### PR DESCRIPTION
## Summary
- redirect `/integrations` to the integrations anchor

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c73233e81c8333bb722f2cab48bb0b