### PR TITLE
Add GoHighLevel links to mobile navigation and footer

### DIFF
--- a/Footer.php
+++ b/Footer.php
@@ -16,6 +16,7 @@
                 <a href="/#benefits" class="block text-slate-300 hover:text-brand-teal">Payment Services</a>
                 <a href="/#integrations" class="block text-slate-300 hover:text-brand-teal">Integrations</a>
                 <a href="shopify.php" class="block text-slate-300 hover:text-brand-teal">Shopify Integration</a>
+                <a href="gohighlevel.php" class="block text-slate-300 hover:text-brand-teal">GoHighLevel Integration</a>
                 <a href="/#how-it-works" class="block text-slate-300 hover:text-brand-teal">Setup Checklist</a>
             </nav>
             <nav class="space-y-2">

--- a/Header.php
+++ b/Header.php
@@ -175,6 +175,7 @@
                      <a href="/#benefits" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Payment Services</a>
                      <a href="/#integrations" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Integrations</a>
                      <a href="shopify.php" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Shopify</a>
+                     <a href="gohighlevel.php" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">GoHighLevel</a>
                      <a href="/#how-it-works" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Setup Checklist</a>
                      <a href="compliance.php" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Compliance</a>
                      <a href="mailto:support@merchanthaus.io" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Contact Support</a>


### PR DESCRIPTION
## Summary
- link GoHighLevel from the mobile menu alongside Shopify
- expose GoHighLevel Integration in the footer's Product list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_b_68c7146381ac8333a773f75be53e4588