### PR TITLE
feat: share Shopify header and footer

### DIFF
--- a/Shopify.html
+++ b/Shopify.html
@@ -144,64 +144,6 @@
     </style>
 </head>
 <body class="bg-brand-light text-brand-dark dark:bg-brand-dark dark:text-slate-100">
-
-    <!-- Back to Top Button -->
-    <button id="back-to-top" class="fixed bottom-6 right-6 bg-brand-crimson text-white p-3 rounded-full shadow-lg hidden z-50 hover:bg-opacity-90 transition-opacity duration-300">
-        <i data-lucide="arrow-up" class="h-6 w-6"></i>
-    </button>
-    
-    <!-- Header -->
-    <div id="home" class="sticky top-0 z-30">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
-            <header class="header-glass border border-slate-200/70 dark:border-slate-800 rounded-xl">
-                <div class="relative max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
-                    <a href="#home" class="flex items-center gap-3 group scroll-link">
-                        <svg width="250" height="50" viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg">
-                            <defs>
-                                <linearGradient id="headerGradient" gradientUnits="userSpaceOnUse" x1="55" y1="0" x2="250" y2="0">
-                                    <stop offset="0%" stop-color="#DC143C" />
-                                    <stop offset="45%" stop-color="#DC143C"><animate attributeName="stop-color" values="#DC143C; #FFC0CB; #DC143C" dur="3s" repeatCount="indefinite"/></stop>
-                                    <stop offset="55%" stop-color="#DC143C"><animate attributeName="stop-color" values="#DC143C; #FFC0CB; #DC143C" dur="3s" repeatCount="indefinite"/></stop>
-                                    <stop offset="100%" stop-color="#DC143C" />
-                                </linearGradient>
-                            </defs>
-                            <image href="Shield.png" x="0" y="5" height="40" width="40" />
-                            <g fill="url(#headerGradient)" style="font-family: 'Ubuntu', sans-serif; font-size: 25px; font-weight: 600;">
-                                <text x="55" y="32">MerchantHaus</text>
-                            </g>
-                        </svg>
-                    </a>
-                    <div class="flex items-center gap-6">
-                        <div class="hidden md:flex items-center gap-4 text-sm font-medium text-slate-600 dark:text-slate-300">
-                            <a href="tel:15056006042" class="hover:text-brand-teal">1-505-600-6042</a>
-                            <a href="mailto:support@merchanthaus.io" class="hover:text-brand-teal">support@merchanthaus.io</a>
-                        </div>
-                        <a href="#application-form" class="js-cta bg-brand-crimson hover:bg-opacity-90 text-white border border-transparent px-4 py-2 rounded-full text-sm font-semibold transition-colors duration-300 scroll-link">Get Started</a>
-                        <a href="https://retailmanager.merchant.haus" class="hidden sm:block bg-transparent hover:bg-brand-teal text-brand-teal hover:text-white border border-brand-teal px-4 py-2 rounded-lg text-sm font-semibold transition-colors duration-300">Login</a>
-                         <button id="mobile-menu-button" class="md:hidden p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800">
-                            <i data-lucide="menu" class="h-6 w-6"></i>
-                        </button>
-                    </div>
-                </div>
-            </header>
-        </div>
-    </div>
-    
-    <!-- Mobile Menu Panel -->
-    <div class="relative z-40">
-        <div id="mobile-menu" class="absolute right-4 mt-2 w-72 rounded-xl bg-white dark:bg-[#1c1c1c] shadow-2xl border border-brand-teal p-4 hidden">
-          <nav class="flex flex-col space-y-2 text-base font-medium">
-            <a href="#benefits" class="scroll-link px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Payment Services</a>
-            <a href="#benefits" class="scroll-link px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Integrations</a>
-            <a href="#home" class="scroll-link px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Shopify</a>
-            <a href="#how-it-works" class="scroll-link px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Setup Checklist</a>
-            <a href="mailto:support@merchanthaus.io" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Contact Support</a>
-            <a href="https://retailmanager.merchant.haus" class="sm:hidden block px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white mt-2 pt-2 border-t border-slate-200 dark:border-slate-800">Login</a>
-          </nav>
-        </div>
-    </div>
-
-
     <!-- Main Content -->
     <main class="min-h-screen flex flex-col items-center justify-start">
         <!-- Cell 1: Hero and Benefits -->
@@ -329,83 +271,9 @@
         </div>
     </main>
 
-    <!-- Footer -->
-    <footer class="bg-brand-dark text-brand-light border-t border-slate-800 py-10">
-        <div class="max-w-7xl mx-auto px-4 grid sm:grid-cols-2 lg:grid-cols-4 gap-8 text-sm">
-            <div class="space-y-4">
-                <a href="#home" class="flex items-center gap-3 scroll-link">
-                    <svg width="250" height="50" viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg">
-                        <image href="Shield.png" x="0" y="5" height="40" width="40" />
-                        <g fill="#DC143C" style="font-family: 'Ubuntu', sans-serif; font-size: 25px; font-weight: 600;">
-                            <text x="55" y="32">MerchantHaus</text>
-                        </g>
-                    </svg>
-                </a>
-                <p class="text-brand-silver">plug. play. grow.</p>
-                <div class="text-sm">
-                    <a href="tel:15056006042" class="block hover:text-brand-teal">1-505-600-6042</a>
-                    <a href="mailto:support@merchanthaus.io" class="block hover:text-brand-teal">support@merchanthaus.io</a>
-                </div>
-            </div>
-            <nav class="space-y-2"><h3 class="font-semibold font-ubuntu text-white">Product</h3><a href="#benefits" class="block hover:text-brand-teal scroll-link">Payment Services</a><a href="#benefits" class="block hover:text-brand-teal scroll-link">Integrations</a><a href="#home" class="block hover:text-brand-teal scroll-link">Shopify Integration</a><a href="#how-it-works" class="block hover:text-brand-teal scroll-link">Setup Checklist</a></nav>
-            <nav class="space-y-2"><h3 class="font-semibold font-ubuntu text-white">Support</h3><a href="mailto:support@merchanthaus.io" class="block hover:text-brand-teal">Contact Support</a><a href="/faq.html" class="block hover:text-brand-teal">FAQs</a></nav>
-            <nav class="space-y-2"><h3 class="font-semibold font-ubuntu text-white">Legal</h3><a href="/privacy.html" class="block hover:text-brand-teal">Privacy Policy</a><a href="/terms.html" class="block hover:text-brand-teal">Terms & Conditions</a></nav>
-        </div>
-        <div class="text-center text-xs pt-8 mt-8 border-t border-slate-800/50 text-brand-silver">© <span id="year"></span> MerchantHaus. All rights reserved.</div>
-    </footer>
-
+    <script src="assets/headerFooter.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            if (window.lucide) lucide.createIcons();
-            document.getElementById('year').textContent = new Date().getFullYear();
-
-            // Smooth scrolling for anchor links
-            document.querySelectorAll('a.scroll-link').forEach(anchor => {
-                anchor.addEventListener('click', function (e) {
-                    e.preventDefault();
-                    const targetId = this.getAttribute('href');
-                    const targetElement = document.querySelector(targetId);
-                    if (targetElement) {
-                        const mobileMenu = document.getElementById('mobile-menu');
-                        if(mobileMenu && !mobileMenu.classList.contains('hidden')) {
-                            mobileMenu.classList.add('hidden');
-                        }
-                        targetElement.scrollIntoView({
-                            behavior: 'smooth'
-                        });
-                    }
-                });
-            });
-
-            // Back to Top button logic
-            const backToTopButton = document.getElementById('back-to-top');
-            window.addEventListener('scroll', () => {
-                if (window.scrollY > 300) {
-                    backToTopButton.classList.remove('hidden');
-                } else {
-                    backToTopButton.classList.add('hidden');
-                }
-            });
-            backToTopButton.addEventListener('click', () => {
-                window.scrollTo({ top: 0, behavior: 'smooth' });
-            });
-            
-            // --- Mobile Menu Logic ---
-            const mobileMenuButton = document.getElementById('mobile-menu-button');
-            const mobileMenu = document.getElementById('mobile-menu');
-            
-            if (mobileMenuButton && mobileMenu) {
-                mobileMenuButton.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    mobileMenu.classList.toggle('hidden');
-                });
-
-                document.addEventListener('click', (e) => {
-                    if (!mobileMenu.classList.contains('hidden') && !mobileMenu.contains(e.target) && !mobileMenuButton.contains(e.target)) {
-                        mobileMenu.classList.add('hidden');
-                    }
-                });
-            }
             
             // --- Stars Canvas Logic ---
             const canvas = document.getElementById('mh-stars');

--- a/apply.html
+++ b/apply.html
@@ -17,12 +17,6 @@
 <link href="/shield.ico" rel="icon" type="image/x-icon"/>
 <link href="/shield.ico" rel="shortcut icon" type="image/x-icon"/><link href="/shield.png" rel="apple-touch-icon"/></head>
 <body class="bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100">
-<header class="sticky top-0 z-40 bg-white/75 dark:bg-slate-950/60 backdrop-blur border-b border-slate-200 dark:border-slate-800">
-<div class="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
-<a class="font-extrabold" href="/">MerchantHaus</a>
-<nav class="hidden md:flex items-center gap-6 text-sm"><a href="/services">Payment Services</a><a href="/pricing">Plans &amp; Pricing</a><a href="/contact">Contact Us</a><a href="/setup-checklist">Setup Checklist</a><a href="/privacy">Privacy Policy</a><a href="/terms">Terms &amp; Conditions</a></nav>
-</div>
-</header>
 <main class="max-w-5xl mx-auto px-4 py-10">
 <h1 class="text-3xl md:text-4xl font-extrabold">Merchant Application</h1>
 <p class="mt-2 text-slate-600 dark:text-slate-300">U.S. retail only. Provide the details below — we’ll review and issue your Merchant ID (MID) &amp; access credentials during onboarding.</p>
@@ -91,6 +85,7 @@
 </div>
 </form>
 </main>
+    <script src="assets/headerFooter.js"></script>
 <script>
     // Populate state list (US)
     const states = ["Alabama","Alaska","Arizona","Arkansas","California","Colorado","Connecticut","Delaware","District of Columbia","Florida","Georgia","Hawaii","Idaho","Illinois","Indiana","Iowa","Kansas","Kentucky","Louisiana","Maine","Maryland","Massachusetts","Michigan","Minnesota","Mississippi","Missouri","Montana","Nebraska","Nevada","New Hampshire","New Jersey","New Mexico","New York","North Carolina","North Dakota","Ohio","Oklahoma","Oregon","Pennsylvania","Rhode Island","South Carolina","South Dakota","Tennessee","Texas","Utah","Vermont","Virginia","Washington","West Virginia","Wisconsin","Wyoming"];
@@ -136,5 +131,5 @@
       }
     });
   </script>
-<footer><div><ul><li><a href="/services">Payment Services</a></li><li><a href="/pricing">Plans &amp; Pricing</a></li><li><a href="/setup-checklist">Setup Checklist</a></li><li><a href="/contact">Contact Support</a></li><li><a href="/faqs">FAQs</a></li><li><a href="/privacy">Privacy Policy</a></li><li><a href="/terms">Terms &amp; Conditions</a></li></ul></div><p>Merchant Haus – Payments made simple.</p></footer></body>
+</body>
 </html>

--- a/assets/headerFooter.js
+++ b/assets/headerFooter.js
@@ -1,0 +1,53 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const [header, footer] = await Promise.all([
+      fetch('header.html').then(r => r.text()),
+      fetch('footer.html').then(r => r.text())
+    ]);
+
+    document.body.insertAdjacentHTML('afterbegin', header);
+    document.body.insertAdjacentHTML('beforeend', footer);
+
+    if (window.lucide && window.lucide.createIcons) {
+      window.lucide.createIcons();
+    }
+
+    const year = document.getElementById('year');
+    if (year) year.textContent = new Date().getFullYear();
+
+    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+      anchor.addEventListener('click', e => {
+        e.preventDefault();
+        const target = document.querySelector(anchor.getAttribute('href'));
+        if (target) target.scrollIntoView({ behavior: 'smooth' });
+      });
+    });
+
+    const backToTop = document.getElementById('back-to-top');
+    if (backToTop) {
+      window.addEventListener('scroll', () => {
+        if (window.scrollY > 300) backToTop.classList.remove('hidden');
+        else backToTop.classList.add('hidden');
+      });
+      backToTop.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+    }
+
+    const mobileMenuButton = document.getElementById('mobile-menu-button');
+    const mobileMenu = document.getElementById('mobile-menu');
+    if (mobileMenuButton && mobileMenu) {
+      mobileMenuButton.addEventListener('click', e => {
+        e.stopPropagation();
+        mobileMenu.classList.toggle('hidden');
+      });
+      document.addEventListener('click', e => {
+        if (!mobileMenu.contains(e.target) && !mobileMenuButton.contains(e.target)) {
+          mobileMenu.classList.add('hidden');
+        }
+      });
+    }
+  } catch (err) {
+    console.error('Failed to load header or footer', err);
+  }
+});

--- a/compliance.html
+++ b/compliance.html
@@ -88,45 +88,6 @@
     <link rel="manifest" href="shield/site.webmanifest">
 </head>
 <body class="bg-white text-slate-900 dark:bg-transparent dark:text-slate-100">
-
-    <!-- Header -->
-    <div class="sticky top-0 z-50">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
-            <header class="header-glass border border-slate-200/70 dark:border-slate-800 rounded-xl">
-                <div class="relative max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
-                    <a href="index.html" class="flex items-center gap-3 group">
-                        <img src="shield/shield.png" alt="MerchantHaus Logo" class="h-10 w-10">
-                        <div>
-                            <div class="text-xl md:text-2xl font-ubuntu font-bold tracking-wide grad-text">MerchantHaus</div>
-                            <p class="text-xs text-slate-500 dark:text-slate-400 h-4">Simple. Safe. Secure.</p>
-                        </div>
-                    </a>
-                    <div class="flex items-center gap-2">
-                        <!-- UPDATED: href changed to # to trigger JS -->
-                        <a href="#" class="js-cta bg-brand-600 hover:bg-brand-700 text-white border border-transparent px-4 py-2 rounded-full text-sm font-semibold transition-colors duration-300">Get Started</a>
-                        <a href="#" class="hidden sm:block bg-transparent text-slate-500 dark:text-slate-400 border border-slate-300 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 px-4 py-2 rounded-lg text-sm font-semibold transition-colors duration-300">Login</a>
-                        <button id="open-menu-btn" class="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" aria-label="Open menu"><i data-lucide="menu" class="h-5 w-5"></i></button>
-                    </div>
-                    <!-- Pop-out Menu -->
-                    <div id="popout-menu" class="absolute top-full right-4 mt-2 w-72 rounded-xl bg-white dark:bg-[#1c1c1c] shadow-2xl border border-slate-200/70 dark:border-slate-800 p-4 z-[51] hidden opacity-0 transition-opacity duration-300">
-                        <nav class="flex flex-col space-y-1 text-base font-medium">
-                            <a href="index.html#payments" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Payment Services</a>
-                            <a href="index.html#integrations" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Integrations</a>
-                            <a href="index.html#checklist" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Setup Checklist</a>
-                            <a href="#" data-close class="js-support px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Contact Support</a>
-                            <a href="#" data-close class="sm:hidden block px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors mt-2 pt-2 border-t border-slate-200 dark:border-slate-800">Login</a>
-                        </nav>
-                        <div class="mt-4 pt-4 border-t border-slate-200 dark:border-slate-800">
-                            <p class="text-xs text-center text-slate-500 dark:text-slate-400">
-                                Questions? Call <a href="tel:15056006042" class="text-brand-600 dark:text-brand-400 hover:underline">1-505-600-6042</a> or email us at <a href="mailto:support@merchanthaus.io" class="text-brand-600 dark:text-brand-400 hover:underline">support@merchanthaus.io</a>
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </header>
-        </div>
-    </div>
-
     <!-- Main Content -->
     <main class="min-h-screen max-w-7xl mx-auto pt-12 pb-16 grid grid-cols-1 lg:grid-cols-2 gap-8 p-6">
         <!-- Compliance Checklist Section -->
@@ -232,19 +193,6 @@
     </main>
     
     <!-- Footer -->
-    <footer class="border-t border-slate-200 dark:border-slate-800 py-10">
-        <div class="max-w-7xl mx-auto px-4 grid sm:grid-cols-2 lg:grid-cols-4 gap-8 text-sm">
-            <div class="space-y-3">
-                <a href="index.html" class="flex items-center gap-3"><img src="shield/shield.png" alt="MerchantHaus Logo" class="h-9 w-9"><span class="text-2xl font-ubuntu font-bold tracking-wide grad-text">MerchantHaus</span></a>
-                <p>Payments made simple.</p>
-                <div class="text-sm"><a href="tel:15056006042" class="block">1-505-600-6042</a><a href="mailto:support@merchanthaus.io" class="block">support@merchanthaus.io</a></div>
-            </div>
-            <nav class="space-y-2"><h3 class="font-semibold font-ubuntu">Product</h3><a href="index.html#payments" class="block">Payment Services</a><a href="index.html#integrations" class="block">Integrations</a><a href="index.html#checklist" class="block">Setup Checklist</a><a href="compliance.html" class="block">Compliance</a></nav>
-            <nav class="space-y-2"><h3 class="font-semibold font-ubuntu">Support</h3><a href="#" class="js-support block">Contact Support</a><a href="index.html#faq-question" class="block">FAQs</a></nav>
-            <nav class="space-y-2"><h3 class="font-semibold font-ubuntu">Legal</h3><a href="privacy.html" class="block">Privacy Policy</a><a href="terms.html" class="block">Terms & Conditions</a></nav>
-        </div>
-        <div class="text-center text-xs pt-8 mt-8 border-t border-slate-200 dark:border-slate-800">© <span id="year"></span> Merchant Haus. All rights reserved.</div>
-    </footer>
 
     <!-- Modals and Panels -->
     <div id="signup-panel-overlay" class="panel-overlay fixed inset-0 bg-black/60 z-50 opacity-0 invisible">
@@ -280,39 +228,11 @@
     </div>
     <div id="support-modal" class="fixed inset-0 z-[70] hidden"></div>
 
+    <script src="assets/headerFooter.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             if (window.lucide) lucide.createIcons();
-            document.getElementById('year').textContent = new Date().getFullYear();
 
-            // --- Pop-out Menu & Modal Logic ---
-            const menuBtn = document.getElementById('open-menu-btn');
-            const popoutMenu = document.getElementById('popout-menu');
-            if (menuBtn && popoutMenu) {
-                menuBtn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    const isHidden = popoutMenu.classList.contains('hidden');
-                    if (isHidden) {
-                        popoutMenu.classList.remove('hidden');
-                        setTimeout(() => popoutMenu.classList.remove('opacity-0'), 10);
-                    } else {
-                        popoutMenu.classList.add('opacity-0');
-                        setTimeout(() => popoutMenu.classList.add('hidden'), 300);
-                    }
-                });
-                document.addEventListener('click', (e) => {
-                    if (!popoutMenu.classList.contains('hidden') && !popoutMenu.contains(e.target) && !menuBtn.contains(e.target)) {
-                        popoutMenu.classList.add('opacity-0');
-                        setTimeout(() => popoutMenu.classList.add('hidden'), 300);
-                    }
-                });
-                popoutMenu.querySelectorAll('a[data-close]').forEach(link => {
-                    link.addEventListener('click', () => {
-                        popoutMenu.classList.add('opacity-0');
-                        setTimeout(() => popoutMenu.classList.add('hidden'), 300);
-                    });
-                });
-            }
 
             const openPanel = (overlayId, panelId) => {
                 const overlay = document.getElementById(overlayId);

--- a/footer.html
+++ b/footer.html
@@ -1,0 +1,23 @@
+<footer class="bg-brand-dark text-brand-light border-t border-slate-800 py-10">
+  <div class="max-w-7xl mx-auto px-4 grid sm:grid-cols-2 lg:grid-cols-4 gap-8 text-sm">
+    <div class="space-y-4">
+      <a href="index.html" class="flex items-center gap-3">
+        <svg width="250" height="50" viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg">
+          <image href="Shield.png" x="0" y="5" height="40" width="40" />
+          <g fill="#DC143C" style="font-family: 'Ubuntu', sans-serif; font-size: 25px; font-weight: 600;">
+            <text x="55" y="32">MerchantHaus</text>
+          </g>
+        </svg>
+      </a>
+      <p class="text-brand-silver">plug. play. grow.</p>
+      <div class="text-sm">
+        <a href="tel:15056006042" class="block hover:text-brand-teal">1-505-600-6042</a>
+        <a href="mailto:support@merchanthaus.io" class="block hover:text-brand-teal">support@merchanthaus.io</a>
+      </div>
+    </div>
+    <nav class="space-y-2"><h3 class="font-semibold font-ubuntu text-white">Product</h3><a href="index.html#benefits" class="block hover:text-brand-teal">Payment Services</a><a href="index.html#benefits" class="block hover:text-brand-teal">Integrations</a><a href="Shopify.html" class="block hover:text-brand-teal">Shopify Integration</a><a href="index.html#how-it-works" class="block hover:text-brand-teal">Setup Checklist</a></nav>
+    <nav class="space-y-2"><h3 class="font-semibold font-ubuntu text-white">Support</h3><a href="mailto:support@merchanthaus.io" class="block hover:text-brand-teal">Contact Support</a><a href="faq.html" class="block hover:text-brand-teal">FAQs</a></nav>
+    <nav class="space-y-2"><h3 class="font-semibold font-ubuntu text-white">Legal</h3><a href="privacy.html" class="block hover:text-brand-teal">Privacy Policy</a><a href="terms.html" class="block hover:text-brand-teal">Terms & Conditions</a></nav>
+  </div>
+  <div class="text-center text-xs pt-8 mt-8 border-t border-slate-800/50 text-brand-silver">© <span id="year"></span> MerchantHaus. All rights reserved.</div>
+</footer>

--- a/header.html
+++ b/header.html
@@ -1,0 +1,59 @@
+<!-- Back to Top Button -->
+<button id="back-to-top" class="fixed bottom-6 right-6 bg-brand-crimson text-white p-3 rounded-full shadow-lg hidden z-50 hover:bg-opacity-90 transition-opacity duration-300">
+  <i data-lucide="arrow-up" class="h-6 w-6"></i>
+</button>
+
+<!-- Header -->
+<div class="sticky top-0 z-30">
+  <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
+    <header class="header-glass border border-slate-200/70 dark:border-slate-800 rounded-xl">
+      <div class="relative max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
+        <a href="index.html" class="flex items-center gap-3 group">
+          <svg width="250" height="50" viewBox="0 0 250 50" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <linearGradient id="headerGradient" gradientUnits="userSpaceOnUse" x1="55" y1="0" x2="250" y2="0">
+                <stop offset="0%" stop-color="#DC143C" />
+                <stop offset="45%" stop-color="#DC143C">
+                  <animate attributeName="stop-color" values="#DC143C; #FFC0CB; #DC143C" dur="3s" repeatCount="indefinite" />
+                </stop>
+                <stop offset="55%" stop-color="#DC143C">
+                  <animate attributeName="stop-color" values="#DC143C; #FFC0CB; #DC143C" dur="3s" repeatCount="indefinite" />
+                </stop>
+                <stop offset="100%" stop-color="#DC143C" />
+              </linearGradient>
+            </defs>
+            <image href="Shield.png" x="0" y="5" height="40" width="40" />
+            <g fill="url(#headerGradient)" style="font-family: 'Ubuntu', sans-serif; font-size: 25px; font-weight: 600;">
+              <text x="55" y="32">MerchantHaus</text>
+            </g>
+          </svg>
+        </a>
+        <div class="flex items-center gap-6">
+          <div class="hidden md:flex items-center gap-4 text-sm font-medium text-slate-600 dark:text-slate-300">
+            <a href="tel:15056006042" class="hover:text-brand-teal">1-505-600-6042</a>
+            <a href="mailto:support@merchanthaus.io" class="hover:text-brand-teal">support@merchanthaus.io</a>
+          </div>
+          <a href="apply.html" class="js-cta bg-brand-crimson hover:bg-opacity-90 text-white border border-transparent px-4 py-2 rounded-full text-sm font-semibold transition-colors duration-300">Get Started</a>
+          <a href="https://retailmanager.merchant.haus" class="hidden sm:block bg-transparent hover:bg-brand-teal text-brand-teal hover:text-white border border-brand-teal px-4 py-2 rounded-lg text-sm font-semibold transition-colors duration-300">Login</a>
+          <button id="mobile-menu-button" class="md:hidden p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800">
+            <i data-lucide="menu" class="h-6 w-6"></i>
+          </button>
+        </div>
+      </div>
+    </header>
+  </div>
+</div>
+
+<!-- Mobile Menu Panel -->
+<div class="relative z-40">
+  <div id="mobile-menu" class="absolute right-4 mt-2 w-72 rounded-xl bg-white dark:bg-[#1c1c1c] shadow-2xl border border-brand-teal p-4 hidden">
+    <nav class="flex flex-col space-y-2 text-base font-medium">
+      <a href="index.html#benefits" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Payment Services</a>
+      <a href="index.html#benefits" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Integrations</a>
+      <a href="Shopify.html" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Shopify</a>
+      <a href="index.html#how-it-works" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Setup Checklist</a>
+      <a href="mailto:support@merchanthaus.io" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Contact Support</a>
+      <a href="https://retailmanager.merchant.haus" class="sm:hidden block px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white mt-2 pt-2 border-t border-slate-200 dark:border-slate-800">Login</a>
+    </nav>
+  </div>
+</div>

--- a/index.html
+++ b/index.html
@@ -209,39 +209,6 @@
 
 <body class="bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100">
   
-  <div class="sticky top-0 z-50">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4 pb-4">
-      <header class="header-glass border border-slate-200/70 dark:border-slate-800 rounded-xl">
-        <div class="relative max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
-          <a href="#" class="flex items-center gap-3 group">
-            <div class="w-[190px] md:w-[260px]" data-mh-logo></div>
-            <noscript>
-              <img src="Shield/Shield.png" alt="MerchantHaus" class="h-10" />
-            </noscript>
-          </a>
-          <div class="flex items-center gap-2">
-            <a href="#" class="js-cta bg-transparent hover:bg-brand-600 text-brand-600 hover:text-white border border-brand-600 px-4 py-2 rounded-full text-sm font-semibold transition-colors duration-300">Get Started</a>
-            <a href="https://retailmanager.merchant.haus" class="hidden sm:block bg-transparent hover:bg-brand-green text-brand-green hover:text-slate-800 border border-brand-green px-4 py-2 rounded-lg text-sm font-semibold transition-colors duration-300">Login</a>
-            <button id="open-menu-btn" class="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" aria-label="Open menu"><i data-lucide="menu" class="h-5 w-5"></i></button>
-          </div>
-           <div id="popout-menu" class="absolute top-full right-4 mt-2 w-72 rounded-xl bg-white dark:bg-[#1c1c1c] shadow-2xl border border-brand-green p-4 z-[51] hidden opacity-0 transition-opacity duration-300">
-            <nav class="flex flex-col space-y-1 text-base font-medium">
-                <a href="#payments" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Payment Services</a>
-                <a href="#integrations" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Integrations</a>
-                <a href="Shopify.html" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Shopify</a>
-                <a href="#checklist" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Setup Checklist</a>
-                <a href="#" data-close class="js-support px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Contact Support</a>
-                <a href="https://retailmanager.merchant.haus" data-close class="sm:hidden block px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors mt-2 pt-2 border-t border-slate-200 dark:border-slate-800">Login</a>
-            </nav>
-            <div class="mt-4 pt-4 border-t border-slate-200 dark:border-slate-800">
-                <p class="text-xs text-center text-slate-500 dark:text-slate-400">
-                    Questions? Call <a href="tel:15056006042" class="text-brand-600 dark:text-brand-400 hover:underline">1-505-600-6042</a> or email us at <a href="mailto:support@merchanthaus.io" class="text-brand-600 dark:text-brand-400 hover:underline">support@merchanthaus.io</a>
-                </p>
-            </div>
-          </div>
-        </div>
-      </header>
-    </div>
 
 
   <div class="relative">
@@ -376,41 +343,6 @@
     </div>
   </div>
 
-  <footer class="border-t border-slate-200 dark:border-slate-800 py-10">
-    <div class="max-w-7xl mx-auto px-4 grid sm:grid-cols-2 lg:grid-cols-4 gap-8 text-sm">
-      <div class="space-y-3">
-        <a href="#" class="flex items-center gap-3">
-            <div class="w-[190px]" data-mh-logo></div>
-            <noscript>
-              <img src="Shield/Shield.png" alt="MerchantHaus" class="h-9" />
-            </noscript>
-        </a>
-        <div class="text-sm">
-            <a href="tel:15056006042" class="block">1-505-600-6042</a>
-            <a href="mailto:support@merchanthaus.io" class="block">support@merchanthaus.io</a>
-        </div>
-      </div>
-      <nav class="space-y-2">
-        <h3 class="font-semibold font-ubuntu">Product</h3>
-        <a href="#payments" class="block">Payment Services</a>
-        <a href="#integrations" class="block">Integrations</a>
-        <a href="Shopify.html" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Shopify</a>
-        <a href="#checklist" class="block">Setup Checklist</a>
-        <a href="compliance.html" class="block">Compliance</a>
-      </nav>
-      <nav class="space-y-2">
-        <h3 class="font-semibold font-ubuntu">Support</h3>
-        <a href="#" class="js-support block">Contact Support</a>
-        <a href="#faq-question" class="block">FAQs</a>
-      </nav>
-      <nav class="space-y-2">
-        <h3 class="font-semibold font-ubuntu">Legal</h3>
-        <a href="Privacy.html" class="block">Privacy Policy</a>
-        <a href="terms.html" class="block">Terms & Conditions</a>
-      </nav>
-    </div>
-    <div class="text-center text-xs pt-8 mt-8 border-t">© <span id="year"></span> Merchant Haus. All rights reserved.</div>
-  </footer>
 
   <div id="signup-panel-overlay" class="panel-overlay fixed inset-0 bg-black/60 z-50 opacity-0 invisible">
     <div id="signup-panel" class="panel-container fixed top-0 right-0 h-full w-full max-w-2xl bg-white dark:bg-slate-900 shadow-2xl transform translate-x-full flex flex-col">
@@ -465,6 +397,7 @@
   </div>
 
 
+  <script src="assets/headerFooter.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {  
         if (window.lucide) lucide.createIcons();  
@@ -503,47 +436,7 @@
             }
         }
     
-        document.getElementById('year').textContent = new Date().getFullYear();
         
-        // Pop-out Menu Logic
-        const menuBtn = document.getElementById('open-menu-btn');
-        const popoutMenu = document.getElementById('popout-menu');
-
-        if (menuBtn && popoutMenu) {
-            menuBtn.addEventListener('click', (e) => {
-                e.stopPropagation();
-                const isHidden = popoutMenu.classList.contains('hidden');
-                if (isHidden) {
-                    popoutMenu.classList.remove('hidden');
-                    setTimeout(() => {
-                        popoutMenu.classList.remove('opacity-0');
-                    }, 10);
-                } else {
-                    popoutMenu.classList.add('opacity-0');
-                    setTimeout(() => {
-                        popoutMenu.classList.add('hidden');
-                    }, 300);
-                }
-            });
-
-            document.addEventListener('click', (e) => {
-                if (!popoutMenu.classList.contains('hidden') && !popoutMenu.contains(e.target) && !menuBtn.contains(e.target)) {
-                    popoutMenu.classList.add('opacity-0');
-                    setTimeout(() => {
-                        popoutMenu.classList.add('hidden');
-                    }, 300);
-                }
-            });
-
-            popoutMenu.querySelectorAll('a[data-close]').forEach(link => {
-                link.addEventListener('click', () => {
-                    popoutMenu.classList.add('opacity-0');
-                    setTimeout(() => {
-                        popoutMenu.classList.add('hidden');
-                    }, 300);
-                });
-            });
-        }
 
         const openPanel = (overlayId, panelId) => {
             document.getElementById(overlayId).classList.remove('invisible', 'opacity-0');

--- a/privacy.html
+++ b/privacy.html
@@ -83,44 +83,6 @@
     <link rel="manifest" href="shield/site.webmanifest">
 </head>
 <body class="bg-white text-slate-900 dark:bg-transparent dark:text-slate-100">
-
-    <!-- Header -->
-    <div class="sticky top-0 z-50">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
-            <header class="header-glass border border-slate-200/70 dark:border-slate-800 rounded-xl">
-                <div class="relative max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
-                    <a href="index.html" class="flex items-center gap-3 group">
-                        <img src="shield/shield.png" alt="MerchantHaus Logo" class="h-10 w-10">
-                        <div>
-                            <div class="text-xl md:text-2xl font-ubuntu font-bold tracking-wide grad-text">MerchantHaus</div>
-                            <p class="text-xs text-slate-500 dark:text-slate-400 h-4">Simple. Safe. Secure.</p>
-                        </div>
-                    </a>
-                    <div class="flex items-center gap-2">
-                        <a href="#" class="js-cta bg-brand-600 hover:bg-brand-700 text-white border border-transparent px-4 py-2 rounded-full text-sm font-semibold transition-colors duration-300">Get Started</a>
-                        <a href="#" class="hidden sm:block bg-transparent text-slate-500 dark:text-slate-400 border border-slate-300 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 px-4 py-2 rounded-lg text-sm font-semibold transition-colors duration-300">Login</a>
-                        <button id="open-menu-btn" class="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" aria-label="Open menu"><i data-lucide="menu" class="h-5 w-5"></i></button>
-                    </div>
-                    <!-- Pop-out Menu -->
-                    <div id="popout-menu" class="absolute top-full right-4 mt-2 w-72 rounded-xl bg-white dark:bg-[#1c1c1c] shadow-2xl border border-slate-200/70 dark:border-slate-800 p-4 z-[51] hidden opacity-0 transition-opacity duration-300">
-                        <nav class="flex flex-col space-y-1 text-base font-medium">
-                            <a href="index.html#payments" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Payment Services</a>
-                            <a href="index.html#integrations" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Integrations</a>
-                            <a href="index.html#checklist" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Setup Checklist</a>
-                            <a href="#" data-close class="js-support px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Contact Support</a>
-                            <a href="#" data-close class="sm:hidden block px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors mt-2 pt-2 border-t border-slate-200 dark:border-slate-800">Login</a>
-                        </nav>
-                        <div class="mt-4 pt-4 border-t border-slate-200 dark:border-slate-800">
-                            <p class="text-xs text-center text-slate-500 dark:text-slate-400">
-                                Questions? Call <a href="tel:15056006042" class="text-brand-600 dark:text-brand-400 hover:underline">1-505-600-6042</a> or email us at <a href="mailto:support@merchanthaus.io" class="text-brand-600 dark:text-brand-400 hover:underline">support@merchanthaus.io</a>
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </header>
-        </div>
-    </div>
-
     <!-- Main Content -->
     <main class="min-h-screen pt-12 pb-16 flex flex-col items-center justify-start p-6">
         <div class="w-full max-w-3xl bg-white/80 dark:bg-[#1c1c1c]/80 backdrop-blur-sm p-8 rounded-xl shadow-lg border border-slate-200/70 dark:border-slate-800">
@@ -216,51 +178,16 @@
     </main>
 
     <!-- Footer -->
-    <footer class="border-t border-slate-200 dark:border-slate-800 py-10">
-        <div class="max-w-7xl mx-auto px-4 grid sm:grid-cols-2 lg:grid-cols-4 gap-8 text-sm">
-            <div class="space-y-3">
-                <a href="index.html" class="flex items-center gap-3"><img src="shield/shield.png" alt="MerchantHaus Logo" class="h-9 w-9"><span class="text-2xl font-ubuntu font-bold tracking-wide grad-text">MerchantHaus</span></a>
-                <p>Payments made simple.</p>
-                <div class="text-sm"><a href="tel:15056006042" class="block">1-505-600-6042</a><a href="mailto:support@merchanthaus.io" class="block">support@merchanthaus.io</a></div>
-            </div>
-            <nav class="space-y-2"><h3 class="font-semibold font-ubuntu">Product</h3><a href="index.html#payments" class="block">Payment Services</a><a href="index.html#integrations" class="block">Integrations</a><a href="index.html#checklist" class="block">Setup Checklist</a><a href="compliance.html" class="block">Compliance</a></nav>
-            <nav class="space-y-2"><h3 class="font-semibold font-ubuntu">Support</h3><a href="#" class="js-support block">Contact Support</a><a href="index.html#faq-question" class="block">FAQs</a></nav>
-            <nav class="space-y-2"><h3 class="font-semibold font-ubuntu">Legal</h3><a href="privacy.html" class="block">Privacy Policy</a><a href="terms.html" class="block">Terms & Conditions</a></nav>
-        </div>
-        <div class="text-center text-xs pt-8 mt-8 border-t border-slate-200 dark:border-slate-800">© <span id="year"></span> Merchant Haus. All rights reserved.</div>
-    </footer>
 
     <!-- Modals and Panels (structure only) -->
     <div id="signup-panel-overlay" class="panel-overlay fixed inset-0 bg-black/60 z-50 opacity-0 invisible"><div id="signup-panel" class="panel-container fixed top-0 right-0 h-full w-full max-w-2xl bg-white dark:bg-slate-900 shadow-2xl transform translate-x-full flex flex-col"></div></div>
     <div id="support-modal" class="fixed inset-0 z-[70] hidden"></div>
 
+    <script src="assets/headerFooter.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             if (window.lucide) lucide.createIcons();
-            document.getElementById('year').textContent = new Date().getFullYear();
 
-            // --- Pop-out Menu & Modal Logic ---
-            const menuBtn = document.getElementById('open-menu-btn');
-            const popoutMenu = document.getElementById('popout-menu');
-            if (menuBtn && popoutMenu) {
-                menuBtn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    popoutMenu.classList.toggle('hidden');
-                    setTimeout(() => popoutMenu.classList.toggle('opacity-0'), 10);
-                });
-                document.addEventListener('click', (e) => {
-                    if (!popoutMenu.classList.contains('hidden') && !popoutMenu.contains(e.target) && !menuBtn.contains(e.target)) {
-                        popoutMenu.classList.add('opacity-0');
-                        setTimeout(() => popoutMenu.classList.add('hidden'), 300);
-                    }
-                });
-                popoutMenu.querySelectorAll('a[data-close]').forEach(link => {
-                    link.addEventListener('click', () => {
-                        popoutMenu.classList.add('opacity-0');
-                        setTimeout(() => popoutMenu.classList.add('hidden'), 300);
-                    });
-                });
-            }
         });
     </script>
 </body>

--- a/terms.html
+++ b/terms.html
@@ -83,44 +83,6 @@
     <link rel="manifest" href="shield/site.webmanifest">
 </head>
 <body class="bg-white text-slate-900 dark:bg-transparent dark:text-slate-100">
-
-    <!-- Header -->
-    <div class="sticky top-0 z-50">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
-            <header class="header-glass border border-slate-200/70 dark:border-slate-800 rounded-xl">
-                <div class="relative max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
-                    <a href="index.html" class="flex items-center gap-3 group">
-                        <img src="shield/shield.png" alt="MerchantHaus Logo" class="h-10 w-10">
-                        <div>
-                            <div class="text-xl md:text-2xl font-ubuntu font-bold tracking-wide grad-text">MerchantHaus</div>
-                            <p class="text-xs text-slate-500 dark:text-slate-400 h-4">Simple. Safe. Secure.</p>
-                        </div>
-                    </a>
-                    <div class="flex items-center gap-2">
-                        <a href="#" class="js-cta bg-brand-600 hover:bg-brand-700 text-white border border-transparent px-4 py-2 rounded-full text-sm font-semibold transition-colors duration-300">Get Started</a>
-                        <a href="#" class="hidden sm:block bg-transparent text-slate-500 dark:text-slate-400 border border-slate-300 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-800 px-4 py-2 rounded-lg text-sm font-semibold transition-colors duration-300">Login</a>
-                        <button id="open-menu-btn" class="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" aria-label="Open menu"><i data-lucide="menu" class="h-5 w-5"></i></button>
-                    </div>
-                    <!-- Pop-out Menu -->
-                    <div id="popout-menu" class="absolute top-full right-4 mt-2 w-72 rounded-xl bg-white dark:bg-[#1c1c1c] shadow-2xl border border-slate-200/70 dark:border-slate-800 p-4 z-[51] hidden opacity-0 transition-opacity duration-300">
-                        <nav class="flex flex-col space-y-1 text-base font-medium">
-                            <a href="index.html#payments" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Payment Services</a>
-                            <a href="index.html#integrations" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Integrations</a>
-                            <a href="index.html#checklist" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Setup Checklist</a>
-                            <a href="#" data-close class="js-support px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Contact Support</a>
-                            <a href="#" data-close class="sm:hidden block px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors mt-2 pt-2 border-t border-slate-200 dark:border-slate-800">Login</a>
-                        </nav>
-                        <div class="mt-4 pt-4 border-t border-slate-200 dark:border-slate-800">
-                            <p class="text-xs text-center text-slate-500 dark:text-slate-400">
-                                Questions? Call <a href="tel:15056006042" class="text-brand-600 dark:text-brand-400 hover:underline">1-505-600-6042</a> or email us at <a href="mailto:support@merchanthaus.io" class="text-brand-600 dark:text-brand-400 hover:underline">support@merchanthaus.io</a>
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </header>
-        </div>
-    </div>
-
     <!-- Main Content -->
     <main class="min-h-screen pt-12 pb-16 flex flex-col items-center justify-start p-6">
         <div class="w-full max-w-3xl bg-white/80 dark:bg-[#1c1c1c]/80 backdrop-blur-sm p-8 rounded-xl shadow-lg border border-slate-200/70 dark:border-slate-800">
@@ -229,51 +191,16 @@
     </main>
 
     <!-- Footer -->
-    <footer class="border-t border-slate-200 dark:border-slate-800 py-10">
-        <div class="max-w-7xl mx-auto px-4 grid sm:grid-cols-2 lg:grid-cols-4 gap-8 text-sm">
-            <div class="space-y-3">
-                <a href="index.html" class="flex items-center gap-3"><img src="shield/shield.png" alt="MerchantHaus Logo" class="h-9 w-9"><span class="text-2xl font-ubuntu font-bold tracking-wide grad-text">MerchantHaus</span></a>
-                <p>Payments made simple.</p>
-                <div class="text-sm"><a href="tel:15056006042" class="block">1-505-600-6042</a><a href="mailto:support@merchanthaus.io" class="block">support@merchanthaus.io</a></div>
-            </div>
-            <nav class="space-y-2"><h3 class="font-semibold font-ubuntu">Product</h3><a href="index.html#payments" class="block">Payment Services</a><a href="index.html#integrations" class="block">Integrations</a><a href="index.html#checklist" class="block">Setup Checklist</a><a href="compliance.html" class="block">Compliance</a></nav>
-            <nav class="space-y-2"><h3 class="font-semibold font-ubuntu">Support</h3><a href="#" class="js-support block">Contact Support</a><a href="index.html#faq-question" class="block">FAQs</a></nav>
-            <nav class="space-y-2"><h3 class="font-semibold font-ubuntu">Legal</h3><a href="privacy.html" class="block">Privacy Policy</a><a href="terms.html" class="block">Terms & Conditions</a></nav>
-        </div>
-        <div class="text-center text-xs pt-8 mt-8 border-t border-slate-200 dark:border-slate-800">© <span id="year"></span> Merchant Haus. All rights reserved.</div>
-    </footer>
 
     <!-- Modals and Panels (structure only) -->
     <div id="signup-panel-overlay" class="panel-overlay fixed inset-0 bg-black/60 z-50 opacity-0 invisible"><div id="signup-panel" class="panel-container fixed top-0 right-0 h-full w-full max-w-2xl bg-white dark:bg-slate-900 shadow-2xl transform translate-x-full flex flex-col"></div></div>
     <div id="support-modal" class="fixed inset-0 z-[70] hidden"></div>
 
+    <script src="assets/headerFooter.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             if (window.lucide) lucide.createIcons();
-            document.getElementById('year').textContent = new Date().getFullYear();
 
-            // --- Pop-out Menu & Modal Logic ---
-            const menuBtn = document.getElementById('open-menu-btn');
-            const popoutMenu = document.getElementById('popout-menu');
-            if (menuBtn && popoutMenu) {
-                menuBtn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    popoutMenu.classList.toggle('hidden');
-                    setTimeout(() => popoutMenu.classList.toggle('opacity-0'), 10);
-                });
-                document.addEventListener('click', (e) => {
-                    if (!popoutMenu.classList.contains('hidden') && !popoutMenu.contains(e.target) && !menuBtn.contains(e.target)) {
-                        popoutMenu.classList.add('opacity-0');
-                        setTimeout(() => popoutMenu.classList.add('hidden'), 300);
-                    }
-                });
-                popoutMenu.querySelectorAll('a[data-close]').forEach(link => {
-                    link.addEventListener('click', () => {
-                        popoutMenu.classList.add('opacity-0');
-                        setTimeout(() => popoutMenu.classList.add('hidden'), 300);
-                    });
-                });
-            }
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add `header.html` and `footer.html` extracted from Shopify page
- load shared header and footer via `assets/headerFooter.js`
- update all HTML pages to rely on shared layout

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68c7007c6c8c8333944ba394c50ac7d2