### PR TITLE
Configure build to output site to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
     "test": "jest --passWithNoTests",
-    "build": "mkdir -p dist && echo \"Build step not configured\" > dist/README.md"
+    "build": "rm -rf dist && mkdir dist && rsync -av --exclude='dist' --exclude='node_modules' --exclude='.git' --exclude='package.json' --exclude='package-lock.json' --exclude='README.md' --exclude='netlify.toml' --exclude='eslint.config.mjs' --exclude='jest.config.js' ./ dist && php index.php > dist/index.html"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- Copy project files into `dist` during build and render `index.php` to a static `dist/index.html`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c7699df4d08333a1f3861469a234eb