### PR TITLE
Add GoHighLevel integration links

### DIFF
--- a/Footer.php
+++ b/Footer.php
@@ -16,6 +16,7 @@
                 <a href="/#payments" class="block text-slate-300 hover:text-brand-teal">Payment Services</a>
                 <a href="/#integrations" class="block text-slate-300 hover:text-brand-teal">Integrations</a>
                 <a href="Shopify.html" class="block text-slate-300 hover:text-brand-teal">Shopify Integration</a>
+                <a href="gohighlevel.php" class="block text-slate-300 hover:text-brand-teal">GoHighLevel Integration</a>
                 <a href="/#checklist" class="block text-slate-300 hover:text-brand-teal">Setup Checklist</a>
             </nav>
             <nav class="space-y-2">

--- a/Header.php
+++ b/Header.php
@@ -175,6 +175,7 @@
                      <a href="/#payments" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Payment Services</a>
                      <a href="/#integrations" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Integrations</a>
                     <a href="Shopify.html" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Shopify</a>
+                    <a href="gohighlevel.php" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">GoHighLevel</a>
                      <a href="/#checklist" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Setup Checklist</a>
                     <a href="compliance.html" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Compliance</a>
                      <a href="mailto:support@merchanthaus.io" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Contact Support</a>

--- a/gohighlevel.php
+++ b/gohighlevel.php
@@ -1,0 +1,1 @@
+<?php require __DIR__ . '/integrations/gohighlevel.php'; ?>

--- a/index.php
+++ b/index.php
@@ -84,7 +84,7 @@
         <img src="shopifylight.png" alt="Shopify Logo" class="h-12 md:h-14 block dark:hidden">
         <img src="shopifydark.png" alt="Shopify Logo" class="h-12 md:h-14 hidden dark:block">
       </a>
-      <a href="#" class="block hover:scale-105 transition-transform duration-300">
+      <a href="gohighlevel.php" class="block hover:scale-105 transition-transform duration-300">
         <img src="gohighlevellight.png" alt="GoHighLevel Logo" class="h-12 md:h-14 block dark:hidden">
         <img src="gohighleveldark.png" alt="GoHighLevel Logo" class="h-12 md:h-14 hidden dark:block">
       </a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -17,16 +17,26 @@
   <lastmod>2025-08-26T23:47:37+00:00</lastmod>
   <priority>0.80</priority>
 </url>
-<url>
-  <loc>https://merchant.haus/shopify.php</loc>
-  <lastmod>2025-08-26T23:47:37+00:00</lastmod>
-  <priority>0.80</priority>
-</url>
-<url>
-  <loc>https://merchant.haus/compliance</loc>
-  <lastmod>2025-08-26T23:47:37+00:00</lastmod>
-  <priority>0.80</priority>
-</url>
+  <url>
+    <loc>https://merchant.haus/shopify.php</loc>
+    <lastmod>2025-08-26T23:47:37+00:00</lastmod>
+    <priority>0.80</priority>
+  </url>
+  <url>
+    <loc>https://merchant.haus/gohighlevel</loc>
+    <lastmod>2025-08-26T23:47:37+00:00</lastmod>
+    <priority>0.80</priority>
+  </url>
+  <url>
+    <loc>https://merchant.haus/gohighlevel.php</loc>
+    <lastmod>2025-08-26T23:47:37+00:00</lastmod>
+    <priority>0.80</priority>
+  </url>
+  <url>
+    <loc>https://merchant.haus/compliance</loc>
+    <lastmod>2025-08-26T23:47:37+00:00</lastmod>
+    <priority>0.80</priority>
+  </url>
 <url>
   <loc>https://merchant.haus/privacy</loc>
   <lastmod>2025-08-26T23:47:37+00:00</lastmod>


### PR DESCRIPTION
## Summary
- Link GoHighLevel page in home integrations section
- Add GoHighLevel to navigation and footer menus
- Include GoHighLevel URLs in sitemap and expose root wrapper page

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68c773064fc8833383160d3a83b13fea