### PR TITLE
fix: update navigation and footer links to php

### DIFF
--- a/Footer.php
+++ b/Footer.php
@@ -2,7 +2,7 @@
     <footer class="border-t border-slate-800 py-10 mt-16">
         <div class="max-w-7xl mx-auto px-4 grid sm:grid-cols-2 lg:grid-cols-4 gap-8 text-sm" >
             <div class="space-y-4">
-                <a href="index.html" class="flex items-center gap-3">
+                <a href="index.php" class="flex items-center gap-3">
                     <div class="w-[220px]" data-mh-logo-footer></div>
                      <span class="sr-only">MerchantHaus Homepage</span>
                 </a>
@@ -15,7 +15,7 @@
                 <h3 class="font-semibold font-ubuntu text-white">Product</h3>
                 <a href="/#payments" class="block text-slate-300 hover:text-brand-teal">Payment Services</a>
                 <a href="/#integrations" class="block text-slate-300 hover:text-brand-teal">Integrations</a>
-                <a href="Shopify.html" class="block text-slate-300 hover:text-brand-teal">Shopify Integration</a>
+                <a href="shopify.php" class="block text-slate-300 hover:text-brand-teal">Shopify Integration</a>
                 <a href="gohighlevel.php" class="block text-slate-300 hover:text-brand-teal">GoHighLevel Integration</a>
                 <a href="/#checklist" class="block text-slate-300 hover:text-brand-teal">Setup Checklist</a>
             </nav>
@@ -26,8 +26,8 @@
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Legal</h3>
-                <a href="/privacy.html" class="block text-slate-300 hover:text-brand-teal">Privacy Policy</a>
-                <a href="/terms.html" class="block text-slate-300 hover:text-brand-teal">Terms & Conditions</a>
+                <a href="/privacy.php" class="block text-slate-300 hover:text-brand-teal">Privacy Policy</a>
+                <a href="/terms.php" class="block text-slate-300 hover:text-brand-teal">Terms & Conditions</a>
             </nav>
         </div>
         <div class="text-center text-xs pt-8 mt-8 border-t border-slate-800 text-slate-500 font-inter">

--- a/Header.php
+++ b/Header.php
@@ -153,7 +153,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
              <header class="header-glass border border-slate-200/70 dark:border-slate-800 rounded-xl">
                  <div class="relative max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
-                    <a href="index.html" class="flex items-center gap-3 group">
+                    <a href="index.php" class="flex items-center gap-3 group">
                          <div class="w-[190px] md:w-[260px]" data-mh-logo-header></div>
                          <span class="sr-only">MerchantHaus Homepage</span>
                      </a>
@@ -174,10 +174,10 @@
                  <nav class="flex flex-col space-y-2 text-base font-medium font-inter">
                      <a href="/#payments" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Payment Services</a>
                      <a href="/#integrations" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Integrations</a>
-                    <a href="Shopify.html" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Shopify</a>
+                    <a href="shopify.php" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Shopify</a>
                     <a href="gohighlevel.php" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">GoHighLevel</a>
                      <a href="/#checklist" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Setup Checklist</a>
-                    <a href="compliance.html" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Compliance</a>
+                    <a href="compliance.php" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Compliance</a>
                      <a href="mailto:support@merchanthaus.io" class="px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white">Contact Support</a>
                      <a href="https://retailmanager.merchant.haus" class="sm:hidden block px-4 py-2 rounded-lg hover:bg-brand-crimson hover:text-white mt-2 pt-2 border-t border-slate-800">Login</a>
                  </nav>


### PR DESCRIPTION
## Summary
- replace `.html` references with `.php` in navigation and footer
- verify corresponding pages load successfully

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `curl -I 127.0.0.1:8000/index.php`
- `curl -I 127.0.0.1:8000/shopify.php`
- `curl -I 127.0.0.1:8000/compliance.php`
- `curl -I 127.0.0.1:8000/privacy.php`
- `curl -I 127.0.0.1:8000/terms.php`


------
https://chatgpt.com/codex/tasks/task_b_68c774966c808333a2be74cc99273855