### PR TITLE
build: generate html pages from php templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
     "test": "jest --passWithNoTests",
-    "build": "rm -rf dist && mkdir dist && rsync -av --exclude='dist' --exclude='node_modules' --exclude='.git' --exclude='package.json' --exclude='package-lock.json' --exclude='README.md' --exclude='netlify.toml' --exclude='eslint.config.mjs' --exclude='jest.config.js' ./ dist && php index.php > dist/index.html"
+    "build": "rm -rf dist && mkdir -p dist && for f in *.php integrations/*.php; do case \"$(basename \"$f\")\" in Header.php|Footer.php) continue;; esac; out=\"dist/${f%.php}.html\"; mkdir -p \"$(dirname \"$out\")\"; php \"$f\" > \"$out\"; done"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- generate static HTML files from all PHP templates while skipping partials

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c8333d7a048333a563e6aeef1fbbd2