### PR TITLE
Add Netlify redirects for PHP URLs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -21,3 +21,63 @@
   from = "/integrations"
   to = "/#integrations"
   status = 301
+
+[[redirects]]
+  from = "/index.php"
+  to = "/index.html"
+  status = 301
+
+[[redirects]]
+  from = "/shopify.php"
+  to = "/shopify.html"
+  status = 301
+
+[[redirects]]
+  from = "/gohighlevel.php"
+  to = "/gohighlevel.html"
+  status = 301
+
+[[redirects]]
+  from = "/faq.php"
+  to = "/faq.html"
+  status = 301
+
+[[redirects]]
+  from = "/apply.php"
+  to = "/apply.html"
+  status = 301
+
+[[redirects]]
+  from = "/compliance.php"
+  to = "/compliance.html"
+  status = 301
+
+[[redirects]]
+  from = "/privacy.php"
+  to = "/privacy.html"
+  status = 301
+
+[[redirects]]
+  from = "/terms.php"
+  to = "/terms.html"
+  status = 301
+
+[[redirects]]
+  from = "/support.php"
+  to = "/support.html"
+  status = 301
+
+[[redirects]]
+  from = "/signup.php"
+  to = "/signup.html"
+  status = 301
+
+[[redirects]]
+  from = "/integrations/shopify.php"
+  to = "/integrations/shopify.html"
+  status = 301
+
+[[redirects]]
+  from = "/integrations/gohighlevel.php"
+  to = "/integrations/gohighlevel.html"
+  status = 301


### PR DESCRIPTION
## Summary
- add Netlify redirect rules that send PHP URLs to their HTML counterparts so legacy links no longer trigger file downloads
- cover both top-level and integration landing pages to keep navigation consistent across the site

## Testing
- npm run lint
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c8b6d358d083338c4b0b2e2116ed25