### PR TITLE
Ensure image assets resolve from any page

### DIFF
--- a/Footer.php
+++ b/Footer.php
@@ -47,6 +47,7 @@
             if (window.lucide) lucide.createIcons();
             document.getElementById('year').textContent = new Date().getFullYear();
 
+            const logoImagePath = <?php echo json_encode(mh_asset('public/assets/images/Shield.png')); ?>;
             // --- Animated Logo Injection ---
             const logoSVG = (id, tagline = true, shimmer = true) => {
                 const letters = ['M','e','r','c','h','a','n','t','H','a','u','s'];
@@ -78,7 +79,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="public/assets/images/Shield.png" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/Header.php
+++ b/Header.php
@@ -3,6 +3,30 @@
     // Set these on each page before including the header
     $pageTitle = isset($pageTitle) ? $pageTitle : 'MerchantHaus';
     $pageDescription = isset($pageDescription) ? $pageDescription : 'Secure and reliable payment processing solutions.';
+
+    // Determine the base path for assets so images work from any directory depth
+    $documentRoot = isset($_SERVER['DOCUMENT_ROOT']) ? str_replace('\\', '/', rtrim($_SERVER['DOCUMENT_ROOT'], '/')) : '';
+    $projectRoot = str_replace('\\', '/', rtrim(__DIR__, '/'));
+    $mhBasePath = '';
+
+    if ($documentRoot && strpos($projectRoot, $documentRoot) === 0) {
+        $mhBasePath = trim(substr($projectRoot, strlen($documentRoot)), '/');
+    }
+
+    if (!function_exists('mh_asset')) {
+        function mh_asset(string $path): string
+        {
+            global $mhBasePath;
+
+            $normalized = '/' . ltrim($path, '/');
+
+            if (!empty($mhBasePath)) {
+                return '/' . $mhBasePath . $normalized;
+            }
+
+            return $normalized;
+        }
+    }
 ?>
 <!DOCTYPE html>
 <html lang="en" class="dark">
@@ -11,7 +35,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo htmlspecialchars($pageTitle); ?> – MerchantHaus</title>
     <meta name="description" content="<?php echo htmlspecialchars($pageDescription); ?>">
-    <link rel="preload" as="image" href="public/assets/images/banner1.png">
+    <link rel="preload" as="image" href="<?php echo htmlspecialchars(mh_asset('public/assets/images/banner1.png')); ?>">
 
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -141,10 +165,10 @@
     </style>
 
     <!-- Favicons -->
-    <link rel="apple-touch-icon" sizes="180x180" href="Shield/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="Shield/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="Shield/favicon-16x16.png">
-    <link rel="manifest" href="Shield/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="<?php echo htmlspecialchars(mh_asset('Shield/apple-touch-icon.png')); ?>">
+    <link rel="icon" type="image/png" sizes="32x32" href="<?php echo htmlspecialchars(mh_asset('Shield/favicon-32x32.png')); ?>">
+    <link rel="icon" type="image/png" sizes="16x16" href="<?php echo htmlspecialchars(mh_asset('Shield/favicon-16x16.png')); ?>">
+    <link rel="manifest" href="<?php echo htmlspecialchars(mh_asset('Shield/site.webmanifest')); ?>">
 </head>
 <body class="text-slate-100">
 

--- a/Shopify.html
+++ b/Shopify.html
@@ -169,7 +169,7 @@
 <stop offset="100%" stop-color="#DC143C"></stop>
 </lineargradient>
 </defs>
-<image height="40" href="Shield.png" width="40" x="0" y="5"/>
+<image height="40" href="public/assets/images/Shield.png" width="40" x="0" y="5"/>
 <g fill="url(#headerGradient)" style="font-family: 'Ubuntu', sans-serif; font-size: 25px; font-weight: 600;">
 <text x="55" y="32">MerchantHaus</text>
 </g>
@@ -219,15 +219,15 @@
 <div class="grid md:grid-cols-2 items-center gap-8 mb-8">
 <div class="flex justify-center md:justify-end">
 <svg height="100" viewbox="0 0 500 100" width="500" xmlns="http://www.w3.org/2000/svg">
-<image height="80" href="Shield.png" width="80" x="10" y="10"/>
+<image height="80" href="public/assets/images/Shield.png" width="80" x="10" y="10"/>
 <g class="dark:fill-white" fill="#DC143C" style="font-family: 'Ubuntu', sans-serif; font-size: 50px; font-weight: 600;">
 <text x="120" y="60">MerchantHaus</text>
 </g>
 </svg>
 </div>
 <div class="flex justify-center md:justify-start">
-<img alt="Shopify Logo" class="h-16 rounded-lg block dark:hidden" src="shopifylight.png"/>
-<img alt="Shopify Logo" class="h-16 rounded-lg hidden dark:block" src="shopifydark.png"/>
+<img alt="Shopify Logo" class="h-16 rounded-lg block dark:hidden" src="public/assets/images/shopifylight.png"/>
+<img alt="Shopify Logo" class="h-16 rounded-lg hidden dark:block" src="public/assets/images/shopifydark.png"/>
 </div>
 </div>
 <h1 class="text-4xl md:text-5xl font-extrabold font-ubuntu mb-4 flex items-center justify-center flex-wrap gap-x-3">
@@ -279,7 +279,7 @@
 </div>
 </section>
 <!-- Cell 2: How It Works, CTA, NMI -->
-<div class="relative w-full max-w-6xl rounded-xl shadow-lg -mt-16 z-10 mb-16 overflow-hidden border border-slate-200/70 dark:border-slate-800" style="background-image: url('banner1.png'); background-size: cover; background-position: center;">
+<div class="relative w-full max-w-6xl rounded-xl shadow-lg -mt-16 z-10 mb-16 overflow-hidden border border-slate-200/70 dark:border-slate-800" style="background-image: url('public/assets/images/banner1.png'); background-size: cover; background-position: center;">
 <div class="bg-brand-light/80 dark:bg-brand-dark/80 backdrop-blur-sm p-6 sm:p-8">
 <!-- How It Works Section -->
 <section class="pt-10 text-center" id="how-it-works">
@@ -315,7 +315,7 @@
 <section class="mt-16 text-center">
 <p class="text-gray-500 text-sm font-medium mb-2 tracking-wider">POWERED BY</p>
 <a href="https://www.nmi.com/" rel="noopener noreferrer" target="_blank">
-<img alt="NMI Logo" class="h-10 mx-auto" src="nmi.png"/>
+<img alt="NMI Logo" class="h-10 mx-auto" src="public/assets/images/nmi.png"/>
 </a>
 </section>
 </div>
@@ -327,7 +327,7 @@
 <div class="space-y-4">
 <a class="flex items-center gap-3 scroll-link" href="#home">
 <svg height="50" viewbox="0 0 250 50" width="250" xmlns="http://www.w3.org/2000/svg">
-<image height="40" href="Shield.png" width="40" x="0" y="5"/>
+<image height="40" href="public/assets/images/Shield.png" width="40" x="0" y="5"/>
 <g fill="#DC143C" style="font-family: 'Ubuntu', sans-serif; font-size: 25px; font-weight: 600;">
 <text x="55" y="32">MerchantHaus</text>
 </g>

--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@
 .service-cell h3, .service-cell p { opacity: 0; transform: translateY(10px); transition: opacity 0.4s ease-out, transform 0.4s ease-out; }
 .service-cell.is-visible h3 { opacity: 1; transform: translateY(0); transition-delay: 0.2s; }
 .service-cell.is-visible p { opacity: 1; transform: translateY(0); transition-delay: 0.3s; }
-.hero-bg-container::before { content: ''; position: absolute; inset: 0; background-image: url('public/assets/images/hero.png'); background-size: 100%; background-position: center; background-repeat: no-repeat; animation: kenBurns 20s ease-in-out infinite alternate; z-index: -20; }
+.hero-bg-container::before { content: ''; position: absolute; inset: 0; background-image: url('<?php echo htmlspecialchars(mh_asset("public/assets/images/hero.png")); ?>'); background-size: 100%; background-position: center; background-repeat: no-repeat; animation: kenBurns 20s ease-in-out infinite alternate; z-index: -20; }
 @keyframes kenBurns { 0% { transform: scale(1) rotate(0deg); background-position: center; } 100% { transform: scale(1.1) rotate(1deg); background-position: top left; } }
 .panel-overlay, .panel-container { transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); }
 </style>
@@ -81,12 +81,12 @@
     <p class="text-lg text-gray-600 dark:text-slate-300 mb-12">Connect MerchantHaus with the platforms you already use.</p>
     <div class="flex justify-center items-center gap-8 md:gap-16">
       <a href="shopify.html" class="block hover:scale-105 transition-transform duration-300">
-        <img src="public/assets/images/shopifylight.png" alt="Shopify Logo" class="h-12 md:h-14 block dark:hidden">
-        <img src="public/assets/images/shopifydark.png" alt="Shopify Logo" class="h-12 md:h-14 hidden dark:block">
+        <img src="<?php echo htmlspecialchars(mh_asset('public/assets/images/shopifylight.png')); ?>" alt="Shopify Logo" class="h-12 md:h-14 block dark:hidden">
+        <img src="<?php echo htmlspecialchars(mh_asset('public/assets/images/shopifydark.png')); ?>" alt="Shopify Logo" class="h-12 md:h-14 hidden dark:block">
       </a>
       <a href="gohighlevel.html" class="block hover:scale-105 transition-transform duration-300">
-        <img src="public/assets/images/gohighlevellight.png" alt="GoHighLevel Logo" class="h-12 md:h-14 block dark:hidden">
-        <img src="public/assets/images/gohighleveldark.png" alt="GoHighLevel Logo" class="h-12 md:h-14 hidden dark:block">
+        <img src="<?php echo htmlspecialchars(mh_asset('public/assets/images/gohighlevellight.png')); ?>" alt="GoHighLevel Logo" class="h-12 md:h-14 block dark:hidden">
+        <img src="<?php echo htmlspecialchars(mh_asset('public/assets/images/gohighleveldark.png')); ?>" alt="GoHighLevel Logo" class="h-12 md:h-14 hidden dark:block">
       </a>
     </div>
   </div>

--- a/integrations/gohighlevel.php
+++ b/integrations/gohighlevel.php
@@ -7,7 +7,7 @@
 <main class="max-w-5xl mx-auto px-4 py-12">
 <a class="text-sm text-brand-600" href="/">← Back to MerchantHaus</a>
 <header class="mt-4 flex items-center gap-4">
-<img alt="GoHighLevel" class="h-10 w-auto" src="/shield.png"/>
+<img alt="GoHighLevel" class="h-10 w-auto" src="<?php echo htmlspecialchars(mh_asset('public/assets/images/Shield.png')); ?>"/>
 <h1 class="text-3xl font-extrabold">MerchantHaus for GoHighLevel</h1>
 <nav><a href="mailto:support@merchanthaus.io">Contact Us</a><a href="/privacy">Privacy Policy</a><a href="/terms">Terms &amp; Conditions</a></nav></header>
 <p class="mt-3 text-slate-600 dark:text-slate-300">Accept payments in GHL funnels &amp; snapshots, with routing freedom and merchant‑friendly controls.</p>
@@ -60,6 +60,6 @@
 </form>
 </div>
 </div>
-<script src="/assets/app.js"></script>
+<script src="<?php echo htmlspecialchars(mh_asset('assets/app.js')); ?>"></script>
 
 <?php include __DIR__ . '/../Footer.php'; ?>

--- a/integrations/shopify.php
+++ b/integrations/shopify.php
@@ -7,7 +7,7 @@
 <main class="max-w-5xl mx-auto px-4 py-12">
 <a class="text-sm text-brand-600" href="/">← Back to MerchantHaus</a>
 <header class="mt-4 flex items-center gap-4">
-<img alt="Shopify" class="h-10 w-auto" src="/shield.png"/>
+<img alt="Shopify" class="h-10 w-auto" src="<?php echo htmlspecialchars(mh_asset('public/assets/images/Shield.png')); ?>"/>
 <h1 class="text-3xl font-extrabold">MerchantHaus for Shopify</h1>
 <nav><a href="mailto:support@merchanthaus.io">Contact Us</a><a href="/privacy">Privacy Policy</a><a href="/terms">Terms &amp; Conditions</a></nav></header>
 <p class="mt-3 text-slate-600 dark:text-slate-300">Boost approvals, reduce fraud, and keep processor flexibility while selling on Shopify.</p>
@@ -60,6 +60,6 @@
 </form>
 </div>
 </div>
-<script src="/assets/app.js"></script>
+<script src="<?php echo htmlspecialchars(mh_asset('assets/app.js')); ?>"></script>
 
 <?php include __DIR__ . '/../Footer.php'; ?>

--- a/shopify.php
+++ b/shopify.php
@@ -134,15 +134,15 @@
                      <div class="grid md:grid-cols-2 items-center gap-8 mb-8">
                          <div class="flex justify-center md:justify-end">
                             <svg width="500" height="100" viewBox="0 0 500 100" xmlns="http://www.w3.org/2000/svg">
-                               <image href="public/assets/images/Shield.png" x="10" y="10" height="80" width="80" />
+                               <image href="<?php echo htmlspecialchars(mh_asset('public/assets/images/Shield.png')); ?>" x="10" y="10" height="80" width="80" />
                                <g fill="#DC143C" class="dark:fill-white" style="font-family: 'Ubuntu', sans-serif; font-size: 50px; font-weight: 600;">
                                   <text y="60" x="120">MerchantHaus</text>
                                </g>
                             </svg>
                          </div>
                          <div class="flex justify-center md:justify-start">
-                            <img src="public/assets/images/shopifylight.png" alt="Shopify Logo" class="h-16 rounded-lg block dark:hidden">
-                            <img src="public/assets/images/shopifydark.png" alt="Shopify Logo" class="h-16 rounded-lg hidden dark:block">
+                            <img src="<?php echo htmlspecialchars(mh_asset('public/assets/images/shopifylight.png')); ?>" alt="Shopify Logo" class="h-16 rounded-lg block dark:hidden">
+                            <img src="<?php echo htmlspecialchars(mh_asset('public/assets/images/shopifydark.png')); ?>" alt="Shopify Logo" class="h-16 rounded-lg hidden dark:block">
                          </div>
                     </div>
 
@@ -199,7 +199,7 @@
 
         <!-- Cell 2: How It Works, CTA, NMI -->
         <div class="relative w-full max-w-6xl rounded-xl shadow-lg -mt-16 z-10 mb-16 overflow-hidden border border-slate-200/70 dark:border-slate-800"
-            style="background-image: url('public/assets/images/banner1.png'); background-size: cover; background-position: center;">
+            style="background-image: url('<?php echo htmlspecialchars(mh_asset("public/assets/images/banner1.png")); ?>'); background-size: cover; background-position: center;">
             <div class="bg-brand-light/80 dark:bg-brand-dark/80 backdrop-blur-sm p-6 sm:p-8">
                 <!-- How It Works Section -->
                 <section id="how-it-works" class="pt-10 text-center">
@@ -237,7 +237,7 @@
                 <section class="mt-16 text-center">
                      <p class="text-gray-500 text-sm font-medium mb-2 tracking-wider">POWERED BY</p>
                      <a href="https://www.nmi.com/" target="_blank" rel="noopener noreferrer">
-                        <img src="public/assets/images/nmi.png" alt="NMI Logo" class="h-10 mx-auto">
+                        <img src="<?php echo htmlspecialchars(mh_asset('public/assets/images/nmi.png')); ?>" alt="NMI Logo" class="h-10 mx-auto">
                      </a>
                 </section>
             </div>


### PR DESCRIPTION
## Summary
- add a reusable `mh_asset()` helper in the shared header to build absolute asset URLs and update favicon/image preload links
- swap hard-coded image sources in the homepage, Shopify landing page, and shared footer script to use the helper so nested routes load their assets
- update integration pages and the static Shopify HTML export to reference the correct image paths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c9931a5c888333980eeac0019aaf15