### PR TITLE
Copy public assets during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
     "test": "jest --passWithNoTests",
-    "build": "rm -rf dist && mkdir -p dist && for f in *.php integrations/*.php; do case \"$(basename \"$f\")\" in Header.php|Footer.php) continue;; esac; out=\"dist/${f%.php}.html\"; mkdir -p \"$(dirname \"$out\")\"; php \"$f\" > \"$out\"; done"
+    "build": "rm -rf dist && mkdir -p dist && for f in *.php integrations/*.php; do case \"$(basename \"$f\")\" in Header.php|Footer.php) continue;; esac; out=\"dist/${f%.php}.html\"; mkdir -p \"$(dirname \"$out\")\"; php \"$f\" > \"$out\"; done && cp -a public dist/"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- update the build script to copy the `public` directory into `dist` so generated HTML can serve bundled static assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c9b11e546883338e718938f52714a5