### PR TITLE
Allow configuring Gemini chat model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 dist/
+
+# Local Netlify folder
+.netlify

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ BOOKING_URL   = https://calendly.com/merchanthaus
 RESEND_API_KEY= re_bGbMpcNW_93iTgbDbhTwDAuXVQiQzUqyz
 FROM_EMAIL    = admin@merchant.haus
 TEAM_EMAIL    = admin@merchant.haus (optional)
+GEMINI_API_KEY= <your-google-generative-ai-key>
+GEMINI_MODEL  = gemini-1.5-flash (optional override)
 ```
 3) Deploy
 

--- a/functions/gemini-chat.js
+++ b/functions/gemini-chat.js
@@ -18,7 +18,8 @@ exports.handler = async (event) => {
     // Use ESM import with CommonJS wrapper
     const { GoogleGenerativeAI } = await import("@google/generative-ai");
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-    const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
+    const modelName = process.env.GEMINI_MODEL || "gemini-1.5-flash";
+    const model = genAI.getGenerativeModel({ model: modelName });
 
     const chat = model.startChat({
       history: history.map(m => ({


### PR DESCRIPTION
## Summary
- allow `functions/gemini-chat.js` to read the Gemini model from `GEMINI_MODEL`, defaulting to the generally available `gemini-1.5-flash`
- document the `GEMINI_API_KEY` requirement and optional `GEMINI_MODEL` override in the deployment environment variables
- ignore the local `.netlify` folder produced by the Netlify CLI

## Testing
- `npx netlify functions:serve --offline --port 9999`
- `curl -i -X POST http://localhost:9999/.netlify/functions/gemini-chat -H 'Content-Type: application/json' -d '{"prompt":"Hello"}'`


------
https://chatgpt.com/codex/tasks/task_b_68ca5070f5548333bb6d2ac9a766b909