### PR TITLE
Add Squarespace branding to integrations section

### DIFF
--- a/index.php
+++ b/index.php
@@ -114,6 +114,16 @@
           ],
         ],
         [
+          'name' => 'Squarespace',
+          'href' => 'https://www.squarespace.com/',
+          'target' => '_blank',
+          'rel' => 'noopener',
+          'logos' => [
+            'light' => mh_asset('public/assets/images/squarespace-light.svg'),
+            'dark' => mh_asset('public/assets/images/squarespace-dark.svg'),
+          ],
+        ],
+        [
           'name' => 'GoHighLevel',
           'href' => 'gohighlevel.html',
           'logos' => [

--- a/public/assets/images/squarespace-dark.svg
+++ b/public/assets/images/squarespace-dark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="40" viewBox="0 0 200 40" role="img" aria-labelledby="title desc">
+  <title id="title">Squarespace logo</title>
+  <desc id="desc">Squarespace wordmark with light lettering for dark backgrounds</desc>
+  <rect width="200" height="40" fill="none"/>
+  <text x="0" y="28" fill="#ffffff" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="26" font-weight="600" letter-spacing="0.5">Squarespace</text>
+</svg>

--- a/public/assets/images/squarespace-light.svg
+++ b/public/assets/images/squarespace-light.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="40" viewBox="0 0 200 40" role="img" aria-labelledby="title desc">
+  <title id="title">Squarespace logo</title>
+  <desc id="desc">Squarespace wordmark with dark lettering</desc>
+  <rect width="200" height="40" fill="none"/>
+  <text x="0" y="28" fill="#1f1f1f" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="26" font-weight="600" letter-spacing="0.5">Squarespace</text>
+</svg>


### PR DESCRIPTION
## Summary
- add Squarespace to the integrations tiles on the homepage index section
- provide light and dark SVG wordmark assets for the Squarespace branding

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_b_68ca91b856808333865999a901e2b486