### PR TITLE
Style header pill shape

### DIFF
--- a/Header.php
+++ b/Header.php
@@ -174,9 +174,9 @@
 
     <!-- Header -->
     <div class="sticky top-0 z-50">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
-             <header class="header-glass border border-slate-200/70 dark:border-slate-800 rounded-xl">
-                 <div class="relative max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4 pb-6">
+             <header class="header-glass border border-slate-200/70 dark:border-slate-800 rounded-full shadow-lg">
+                 <div class="relative max-w-7xl mx-auto px-6 py-3 flex items-center justify-between">
                     <a href="index.html" class="flex items-center gap-3 group">
                          <div class="w-[190px] md:w-[260px]" data-mh-logo-header></div>
                          <span class="sr-only">MerchantHaus Homepage</span>


### PR DESCRIPTION
## Summary
- restyle the header container with a fully rounded pill appearance and subtle shadow
- add extra bottom padding around the sticky header so it no longer touches the hero section

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ca91e22c20833385a35c662bb59fc9