### PR TITLE
Ensure header signup panel opens on every page

### DIFF
--- a/Footer.php
+++ b/Footer.php
@@ -57,6 +57,8 @@
     </button>
 
 
+    <script src="<?php echo htmlspecialchars(mh_asset('assets/signup-panel.js')); ?>" defer></script>
+    
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             if (window.lucide) lucide.createIcons();

--- a/Header.php
+++ b/Header.php
@@ -186,7 +186,7 @@
                              <a href="tel:15056006042" class="hover:text-brand-teal transition-colors">1-505-600-6042</a>
                              <a href="mailto:support@merchanthaus.io" class="hover:text-brand-teal transition-colors">support@merchanthaus.io</a>
                          </div>
-                         <a href="/#checklist" class="js-cta bg-brand-crimson hover:bg-opacity-90 text-white border border-transparent px-4 py-2 rounded-full text-sm font-semibold font-inter transition-colors duration-300">Get Started</a>
+                         <button type="button" class="js-signup-cta bg-brand-crimson hover:bg-opacity-90 text-white border border-transparent px-4 py-2 rounded-full text-sm font-semibold font-inter transition-colors duration-300">Get Started</button>
                          <a href="https://retailmanager.merchant.haus" class="hidden sm:block bg-transparent hover:bg-brand-teal text-brand-teal hover:text-white border border-brand-teal px-4 py-2 rounded-lg text-sm font-semibold font-inter transition-colors duration-300">Login</a>
                          <button id="mobile-menu-button" class="md:hidden p-2 rounded-lg hover:bg-slate-800">
                              <i data-lucide="menu" class="h-6 w-6"></i>
@@ -232,6 +232,40 @@
                      </div>
                      <a href="https://retailmanager.merchant.haus" class="sm:hidden block w-full px-4 py-2 text-center rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Login</a>
                  </nav>
+            </div>
+        </div>
+    </div>
+
+    <div id="signup-panel-overlay" class="panel-overlay fixed inset-0 bg-black/60 z-50 opacity-0 invisible">
+        <div id="signup-panel" class="panel-container fixed top-0 right-0 h-full w-full max-w-2xl bg-white dark:bg-slate-900 shadow-2xl transform translate-x-full flex flex-col">
+            <div class="p-6 sm:p-8 relative flex-shrink-0">
+                <button id="close-signup-panel-btn" class="absolute top-4 right-4 text-slate-500 hover:text-slate-800 dark:hover:text-slate-200">
+                    <i data-lucide="x" class="h-6 w-6"></i>
+                </button>
+                <div class="mb-6">
+                    <div class="flex justify-between mb-2 text-sm font-semibold text-slate-800 dark:text-slate-200">
+                        <p>Step <span id="current-step-text">1</span> of 3</p>
+                        <p id="step-name">Account Details</p>
+                    </div>
+                    <div class="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2.5 overflow-hidden">
+                        <div id="progress-bar" class="bg-brand-crimson h-full rounded-full" style="width: 33%"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="px-6 sm:px-8 pb-4 flex-grow overflow-y-auto">
+                <form id="signup-form" novalidate></form>
+                <div id="form-message" class="mt-4 text-center text-sm"></div>
+            </div>
+            <div class="p-6 sm:p-8 mt-auto pt-6 border-t border-slate-200 dark:border-slate-800 flex justify-between items-center flex-shrink-0">
+                <div class="text-sm">
+                    <p class="font-semibold">Need Help?</p>
+                    <a href="tel:15056006042" class="text-slate-500 hover:text-brand-crimson dark:hover:text-brand-teal transition-colors">1-505-600-6042</a>
+                </div>
+                <div class="flex items-center gap-4">
+                    <button type="button" id="prev-btn" class="bg-slate-200 text-slate-800 dark:bg-slate-700 dark:text-slate-200 px-6 py-2.5 rounded-lg font-semibold hover:bg-slate-300 dark:hover:bg-slate-600 transition-all invisible">Previous</button>
+                    <button type="button" id="next-btn" class="bg-brand-crimson text-white px-6 py-2.5 rounded-lg font-semibold hover:bg-brand-crimson transition-all shadow-sm hover:shadow-md">Next</button>
+                    <button type="submit" id="submit-btn" form="signup-form" class="bg-brand-crimson text-white px-6 py-2.5 rounded-lg font-bold hover:bg-brand-crimson transition-all shadow-sm hover:shadow-md hidden">Create Account</button>
+                </div>
             </div>
         </div>
     </div>

--- a/assets/signup-panel.js
+++ b/assets/signup-panel.js
@@ -1,0 +1,137 @@
+(function () {
+  const ready = (fn) => (document.readyState !== 'loading' ? fn() : document.addEventListener('DOMContentLoaded', fn));
+
+  ready(() => {
+    const overlay = document.getElementById('signup-panel-overlay');
+    const panel = document.getElementById('signup-panel');
+    if (!overlay || !panel) return;
+
+    const closeButton = document.getElementById('close-signup-panel-btn');
+    const triggers = document.querySelectorAll('.js-signup-cta');
+
+    const stepNames = ['Account Details', 'Company Information', 'Finalize Account'];
+    let currentStep = 0;
+    let steps = [];
+    let prevBtn;
+    let nextBtn;
+    let submitBtn;
+    let progressBar;
+    let currentStepText;
+    let stepNameEl;
+    let formInitialized = false;
+
+    const setStep = (index) => {
+      if (!steps.length) return;
+      currentStep = Math.max(0, Math.min(index, steps.length - 1));
+      steps.forEach((step, idx) => {
+        step.classList.toggle('hidden', idx !== currentStep);
+      });
+      if (progressBar) {
+        const width = ((currentStep + 1) / steps.length) * 100;
+        progressBar.style.width = `${width}%`;
+      }
+      if (currentStepText) currentStepText.textContent = currentStep + 1;
+      if (stepNameEl) stepNameEl.textContent = stepNames[currentStep] || '';
+      if (prevBtn) prevBtn.classList.toggle('invisible', currentStep === 0);
+      if (nextBtn) nextBtn.classList.toggle('hidden', currentStep === steps.length - 1);
+      if (submitBtn) submitBtn.classList.toggle('hidden', currentStep !== steps.length - 1);
+    };
+
+    const ensureForm = () => {
+      const form = document.getElementById('signup-form');
+      if (!form) return;
+
+      if (!formInitialized) {
+        form.innerHTML = `
+      <div id="step-1" class="form-step">
+        <h2 class="text-2xl font-bold mb-2">Primary Contact Information</h2>
+        <p class="text-sm text-slate-500 mb-6">This person will be the primary user on the account.</p>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div><label for="firstName" class="block text-sm font-semibold mb-1">First Name*</label><input type="text" id="firstName" name="firstName" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
+          <div><label for="lastName" class="block text-sm font-semibold mb-1">Last Name*</label><input type="text" id="lastName" name="lastName" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
+          <div class="md:col-span-2"><label for="email" class="block text-sm font-semibold mb-1">Email Address*</label><input type="email" id="email" name="email" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
+          <div><label for="phone" class="block text-sm font-semibold mb-1">Phone Number*</label><input type="tel" id="phone" name="phone" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
+          <div><label for="password" class="block text-sm font-semibold mb-1">Password*</label><input type="password" id="password" name="password" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
+        </div>
+      </div>
+      <div id="step-2" class="form-step hidden">
+        <h2 class="text-2xl font-bold mb-6">Company Information</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="md:col-span-2"><label for="companyName" class="block text-sm font-semibold mb-1">Company Name*</label><input type="text" id="companyName" name="companyName" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
+        </div>
+      </div>
+      <div id="step-3" class="form-step hidden">
+        <h2 class="text-2xl font-bold mb-2">Finalize Your Account</h2>
+        <p class="text-sm text-slate-500 mb-6">Create a username for logging into the gateway and accept the terms.</p>
+        <div class="space-y-4">
+          <div><label for="username" class="block text-sm font-semibold mb-1">Primary Username*</label><input type="text" id="username" name="username" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
+          <div class="flex items-start pt-4">
+            <div class="flex items-center h-5"><input id="terms" name="terms" type="checkbox" class="focus:ring-brand-crimson h-4 w-4 text-brand-crimson rounded" required></div>
+            <div class="ml-3 text-sm"><label for="terms">I agree to the <a href="#" class="font-semibold text-brand-crimson hover:underline">Terms and Conditions</a>*</label></div>
+          </div>
+        </div>
+      </div>`;
+
+        steps = Array.from(form.querySelectorAll('.form-step'));
+        prevBtn = document.getElementById('prev-btn');
+        nextBtn = document.getElementById('next-btn');
+        submitBtn = document.getElementById('submit-btn');
+        progressBar = document.getElementById('progress-bar');
+        currentStepText = document.getElementById('current-step-text');
+        stepNameEl = document.getElementById('step-name');
+
+        const goNext = (event) => {
+          event.preventDefault();
+          if (currentStep < steps.length - 1) setStep(currentStep + 1);
+        };
+
+        const goPrev = (event) => {
+          event.preventDefault();
+          if (currentStep > 0) setStep(currentStep - 1);
+        };
+
+        nextBtn?.addEventListener('click', goNext);
+        prevBtn?.addEventListener('click', goPrev);
+
+        formInitialized = true;
+      }
+
+      setStep(0);
+    };
+
+    const openPanel = () => {
+      ensureForm();
+      overlay.classList.remove('invisible', 'opacity-0');
+      panel.classList.remove('translate-x-full');
+    };
+
+    const closePanel = () => {
+      panel.classList.add('translate-x-full');
+      setTimeout(() => {
+        overlay.classList.add('invisible', 'opacity-0');
+      }, 300);
+    };
+
+    triggers.forEach((trigger) => {
+      trigger.addEventListener('click', (event) => {
+        event.preventDefault();
+        openPanel();
+      });
+    });
+
+    closeButton?.addEventListener('click', (event) => {
+      event.preventDefault();
+      closePanel();
+    });
+
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) closePanel();
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !overlay.classList.contains('invisible')) {
+        closePanel();
+      }
+    });
+  });
+})();

--- a/compliance.php
+++ b/compliance.php
@@ -145,32 +145,6 @@
                 });
             }
 
-            const openPanel = (overlayId, panelId) => {
-                const overlay = document.getElementById(overlayId);
-                const panel = document.getElementById(panelId);
-                if(overlay) overlay.classList.remove('invisible', 'opacity-0');
-                if(panel) panel.classList.remove('translate-x-full');
-            };
-            const closePanel = (overlayId, panelId) => {
-                const panel = document.getElementById(panelId);
-                if(panel) panel.classList.add('translate-x-full');
-                const overlay = document.getElementById(overlayId);
-                if(overlay) setTimeout(() => overlay.classList.add('invisible', 'opacity-0'), 300);
-            };
-
-            document.querySelectorAll('.js-cta').forEach(el => {
-                el.addEventListener('click', (e) => {
-                    e.preventDefault();
-                    openPanel('signup-panel-overlay', 'signup-panel');
-                    initializeForm();
-                });
-            });
-            document.getElementById('close-signup-panel-btn')?.addEventListener('click', () => closePanel('signup-panel-overlay', 'signup-panel'));
-            const signupOverlay = document.getElementById('signup-panel-overlay');
-            if(signupOverlay) signupOverlay.addEventListener('click', (e) => {
-                if (e.target.id === 'signup-panel-overlay') closePanel('signup-panel-overlay', 'signup-panel');
-            });
-
             const supportModal = document.getElementById('support-modal');
             document.querySelectorAll('.js-support').forEach(el => {
                 el.addEventListener('click', (e) => { e.preventDefault(); if(supportModal) supportModal.classList.remove('hidden'); });
@@ -215,12 +189,6 @@
                 });
             }
 
-            // --- Multi-step form logic ---
-            function initializeForm() {
-                const formContainer = document.getElementById('signup-panel');
-                if (!formContainer) return;
-                // Full multi-step form HTML and logic would be injected here
-            }
         });
     </script>
 

--- a/index.php
+++ b/index.php
@@ -51,7 +51,7 @@
               </button>
             </div>
             <div id="hero-actions" class="flex flex-wrap justify-center items-center gap-3">
-              <button class="js-cta bg-transparent hover:bg-brand-crimson text-brand-crimson hover:text-white border border-brand-crimson px-4 py-2 rounded-full text-sm font-semibold transition-colors duration-300">Get Started</button>
+              <button class="js-signup-cta bg-transparent hover:bg-brand-crimson text-brand-crimson hover:text-white border border-brand-crimson px-4 py-2 rounded-full text-sm font-semibold transition-colors duration-300">Get Started</button>
               <button class="bg-slate-100/20 dark:bg-slate-800/30 text-white px-4 py-2 rounded-full text-sm font-medium hover:bg-slate-200/30 dark:hover:bg-slate-700/40 transition-colors">Chargeback Help</button>
               <button class="js-support bg-slate-100/20 dark:bg-slate-800/30 text-white px-4 py-2 rounded-full text-sm font-medium hover:bg-slate-200/30 dark:hover:bg-slate-700/40 transition-colors">Contact Support</button>
             </div>
@@ -82,7 +82,7 @@
   <div class="mt-8 sm:mt-10 flex justify-center px-4">
     <button
       type="button"
-      class="js-cta inline-flex items-center justify-center rounded-full px-8 py-3 text-lg font-semibold text-white shadow-lg transition-all duration-300 hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-crimson focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
+      class="js-signup-cta inline-flex items-center justify-center rounded-full px-8 py-3 text-lg font-semibold text-white shadow-lg transition-all duration-300 hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-crimson focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900"
       style="background-image: linear-gradient(135deg, #dc143c 0%, #f43f5e 50%, #ff758c 100%);"
     >
       Start accepting payments today
@@ -219,38 +219,6 @@
   </div>
 </div>
 
-<div id="signup-panel-overlay" class="panel-overlay fixed inset-0 bg-black/60 z-50 opacity-0 invisible">
-  <div id="signup-panel" class="panel-container fixed top-0 right-0 h-full w-full max-w-2xl bg-white dark:bg-slate-900 shadow-2xl transform translate-x-full flex flex-col">
-    <div class="p-6 sm:p-8 relative flex-shrink-0">
-      <button id="close-signup-panel-btn" class="absolute top-4 right-4 text-slate-500 hover:text-slate-800 dark:hover:text-slate-200"><i data-lucide="x" class="h-6 w-6"></i></button>
-      <div class="mb-6">
-        <div class="flex justify-between mb-2 text-sm font-semibold text-slate-800 dark:text-slate-200">
-          <p>Step <span id="current-step-text">1</span> of 3</p>
-          <p id="step-name">Account Details</p>
-        </div>
-        <div class="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2.5 overflow-hidden">
-          <div id="progress-bar" class="bg-brand-crimson h-full rounded-full" style="width: 33%"></div>
-        </div>
-      </div>
-    </div>
-    <div class="px-6 sm:px-8 pb-4 flex-grow overflow-y-auto">
-      <form id="signup-form" novalidate></form>
-      <div id="form-message" class="mt-4 text-center text-sm"></div>
-    </div>
-    <div class="p-6 sm:p-8 mt-auto pt-6 border-t border-slate-200 dark:border-slate-800 flex justify-between items-center flex-shrink-0">
-      <div class="text-sm">
-        <p class="font-semibold">Need Help?</p>
-        <a href="tel:15056006042" class="text-slate-500 hover:text-brand-crimson dark:hover:text-brand-teal transition-colors">1-505-600-6042</a>
-      </div>
-      <div class="flex items-center gap-4">
-        <button type="button" id="prev-btn" class="bg-slate-200 text-slate-800 dark:bg-slate-700 dark:text-slate-200 px-6 py-2.5 rounded-lg font-semibold hover:bg-slate-300 dark:hover:bg-slate-600 transition-all invisible">Previous</button>
-        <button type="button" id="next-btn" class="bg-brand-crimson text-white px-6 py-2.5 rounded-lg font-semibold hover:bg-brand-crimson transition-all shadow-sm hover:shadow-md">Next</button>
-        <button type="submit" id="submit-btn" form="signup-form" class="bg-brand-crimson text-white px-6 py-2.5 rounded-lg font-bold hover:bg-brand-crimson transition-all shadow-sm hover:shadow-md hidden">Create Account</button>
-      </div>
-    </div>
-  </div>
-</div>
-
 <div id="support-modal" class="fixed inset-0 z-[70] hidden">
   <div class="absolute inset-0 bg-black/60" data-close></div>
   <div class="mx-auto mt-[10vh] w-[min(560px,92vw)] rounded-2xl bg-white dark:bg-slate-900 p-6 border border-slate-200 dark:border-slate-800 shadow-2xl">
@@ -302,30 +270,6 @@ document.addEventListener('DOMContentLoaded', () => {
     renderServices(container2);
     if (window.lucide) lucide.createIcons();
   }
-
-  const openPanel = (overlayId, panelId) => {
-    document.getElementById(overlayId).classList.remove('invisible', 'opacity-0');
-    document.getElementById(panelId).classList.remove('translate-x-full');
-  };
-  const closePanel = (overlayId, panelId) => {
-    document.getElementById(panelId).classList.add('translate-x-full');
-    setTimeout(() => {
-      document.getElementById(overlayId).classList.add('invisible', 'opacity-0');
-    }, 300);
-  };
-
-  document.querySelectorAll('.js-cta').forEach(el => {
-    el.addEventListener('click', (e) => {
-      e.preventDefault();
-      openPanel('signup-panel-overlay', 'signup-panel');
-      initializeForm();
-    });
-  });
-
-  document.getElementById('close-signup-panel-btn').addEventListener('click', () => closePanel('signup-panel-overlay', 'signup-panel'));
-  document.getElementById('signup-panel-overlay').addEventListener('click', (e) => {
-    if (e.target.id === 'signup-panel-overlay') closePanel('signup-panel-overlay', 'signup-panel');
-  });
 
   const supportModal = document.getElementById('support-modal');
   document.querySelectorAll('.js-support').forEach(el => {
@@ -473,65 +417,6 @@ document.addEventListener('DOMContentLoaded', () => {
   };
   askFaqBtn.addEventListener('click', handleFaqSubmit);
   faqQuestionInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') handleFaqSubmit(); });
-
-  let currentStep = 0;
-  const stepNames = ["Account Details", "Company Information", "Finalize Account"];
-
-  function initializeForm() {
-    const form = document.getElementById('signup-form');
-    if (!form) return;
-    form.innerHTML = `
-      <div id="step-1" class="form-step">
-        <h2 class="text-2xl font-bold mb-2">Primary Contact Information</h2>
-        <p class="text-sm text-slate-500 mb-6">This person will be the primary user on the account.</p>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div><label for="firstName" class="block text-sm font-semibold mb-1">First Name*</label><input type="text" id="firstName" name="firstName" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
-          <div><label for="lastName" class="block text-sm font-semibold mb-1">Last Name*</label><input type="text" id="lastName" name="lastName" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
-          <div class="md:col-span-2"><label for="email" class="block text-sm font-semibold mb-1">Email Address*</label><input type="email" id="email" name="email" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
-          <div><label for="phone" class="block text-sm font-semibold mb-1">Phone Number*</label><input type="tel" id="phone" name="phone" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
-          <div><label for="password" class="block text-sm font-semibold mb-1">Password*</label><input type="password" id="password" name="password" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
-        </div>
-      </div>
-      <div id="step-2" class="form-step hidden">
-        <h2 class="text-2xl font-bold mb-6">Company Information</h2>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="md:col-span-2"><label for="companyName" class="block text-sm font-semibold mb-1">Company Name*</label><input type="text" id="companyName" name="companyName" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
-        </div>
-      </div>
-      <div id="step-3" class="form-step hidden">
-        <h2 class="text-2xl font-bold mb-2">Finalize Your Account</h2>
-        <p class="text-sm text-slate-500 mb-6">Create a username for logging into the gateway and accept the terms.</p>
-        <div class="space-y-4">
-          <div><label for="username" class="block text-sm font-semibold mb-1">Primary Username*</label><input type="text" id="username" name="username" class="w-full p-3 rounded-lg bg-slate-100 dark:bg-slate-800" required></div>
-          <div class="flex items-start pt-4">
-            <div class="flex items-center h-5"><input id="terms" name="terms" type="checkbox" class="focus:ring-brand-crimson h-4 w-4 text-brand-crimson rounded" required></div>
-            <div class="ml-3 text-sm"><label for="terms">I agree to the <a href="#" class="font-semibold text-brand-crimson hover:underline">Terms and Conditions</a>*</label></div>
-          </div>
-        </div>
-      </div>`;
-    const steps = form.querySelectorAll('.form-step');
-    const prevBtn = document.getElementById('prev-btn');
-    const nextBtn = document.getElementById('next-btn');
-    const submitBtn = document.getElementById('submit-btn');
-    const progressBar = document.getElementById('progress-bar');
-    const currentStepText = document.getElementById('current-step-text');
-    const stepNameEl = document.getElementById('step-name');
-
-    function updateFormStep() {
-      steps.forEach((step, index) => {
-        step.classList.toggle('hidden', index !== currentStep);
-      });
-      progressBar.style.width = `${((currentStep + 1) / steps.length) * 100}%`;
-      currentStepText.textContent = currentStep + 1;
-      stepNameEl.textContent = stepNames[currentStep];
-      prevBtn.classList.toggle('invisible', currentStep === 0);
-      nextBtn.classList.toggle('hidden', currentStep === steps.length - 1);
-      submitBtn.classList.toggle('hidden', currentStep !== steps.length - 1);
-    }
-    nextBtn.addEventListener('click', () => { if (currentStep < steps.length - 1) { currentStep++; updateFormStep(); } });
-    prevBtn.addEventListener('click', () => { if (currentStep > 0) { currentStep--; updateFormStep(); } });
-    updateFormStep();
-  }
 
   const supportForm = document.getElementById('support-form');
   const supportOut = document.getElementById('support-out');


### PR DESCRIPTION
## Summary
- place the multi-step signup panel markup in the shared header and update the CTA button to a script-driven trigger
- introduce a global signup-panel.js helper that initializes the form on demand and load it from the shared footer
- point homepage signup calls-to-action at the shared trigger so the panel opens without redirecting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68caa06d798c8333a3543630b769f777