### PR TITLE
Align Shopify and GoHighLevel integration links

### DIFF
--- a/Footer.php
+++ b/Footer.php
@@ -29,8 +29,8 @@
                     </span>
                 </button>
                 <div id="footer-integrations-menu" class="mt-2 space-y-2 pl-4 hidden">
-                    <a href="shopify.html" class="block text-slate-400 hover:text-brand-teal">Shopify Integration</a>
-                    <a href="gohighlevel.html" class="block text-slate-400 hover:text-brand-teal">GoHighLevel Integration</a>
+                    <a href="Shopify.html" class="block text-slate-400 hover:text-brand-teal">Shopify Integration</a>
+                    <a href="gohighlevel.php" class="block text-slate-400 hover:text-brand-teal">GoHighLevel Integration</a>
                 </div>
                 <a href="/#checklist" class="block text-slate-300 hover:text-brand-teal">Setup Checklist</a>
             </nav>

--- a/Header.php
+++ b/Header.php
@@ -214,8 +214,8 @@
                              </span>
                          </button>
                          <div id="mobile-integrations-menu" class="mt-2 space-y-2 pl-3 hidden">
-                             <a href="shopify.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#1f1f1f] text-white transition-colors duration-200 hover:bg-brand-teal">Shopify Integration</a>
-                             <a href="gohighlevel.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#1f1f1f] text-white transition-colors duration-200 hover:bg-brand-teal">GoHighLevel Integration</a>
+                             <a href="Shopify.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#1f1f1f] text-white transition-colors duration-200 hover:bg-brand-teal">Shopify Integration</a>
+                             <a href="gohighlevel.php" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#1f1f1f] text-white transition-colors duration-200 hover:bg-brand-teal">GoHighLevel Integration</a>
                          </div>
                          <a href="/#checklist" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Setup Checklist</a>
                      </div>

--- a/index.php
+++ b/index.php
@@ -130,7 +130,7 @@
       $integrationTiles = [
         [
           'name' => 'Shopify',
-          'href' => 'shopify.html',
+          'href' => 'Shopify.html',
           'logos' => [
             'light' => mh_asset('public/assets/images/shopifylight.png'),
             'dark' => mh_asset('public/assets/images/shopifydark.png'),
@@ -157,7 +157,7 @@
         ],
         [
           'name' => 'GoHighLevel',
-          'href' => 'gohighlevel.html',
+          'href' => 'gohighlevel.php',
           'logos' => [
             'light' => mh_asset('public/assets/images/gohighlevellight.png'),
             'dark' => mh_asset('public/assets/images/gohighleveldark.png'),

--- a/netlify.toml
+++ b/netlify.toml
@@ -29,12 +29,12 @@
 
 [[redirects]]
   from = "/shopify.php"
-  to = "/shopify.html"
+  to = "/Shopify.html"
   status = 301
 
 [[redirects]]
-  from = "/gohighlevel.php"
-  to = "/gohighlevel.html"
+  from = "/gohighlevel.html"
+  to = "/gohighlevel.php"
   status = 301
 
 [[redirects]]
@@ -73,11 +73,11 @@
   status = 301
 
 [[redirects]]
-  from = "/integrations/shopify.php"
-  to = "/integrations/shopify.html"
+  from = "/integrations/shopify.html"
+  to = "/integrations/shopify.php"
   status = 301
 
 [[redirects]]
-  from = "/integrations/gohighlevel.php"
-  to = "/integrations/gohighlevel.html"
+  from = "/integrations/gohighlevel.html"
+  to = "/integrations/gohighlevel.php"
   status = 301

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -18,7 +18,7 @@
   <priority>0.80</priority>
 </url>
   <url>
-    <loc>https://merchant.haus/shopify.html</loc>
+    <loc>https://merchant.haus/Shopify.html</loc>
     <lastmod>2025-08-26T23:47:37+00:00</lastmod>
     <priority>0.80</priority>
   </url>
@@ -28,7 +28,7 @@
     <priority>0.80</priority>
   </url>
   <url>
-    <loc>https://merchant.haus/gohighlevel.html</loc>
+    <loc>https://merchant.haus/gohighlevel.php</loc>
     <lastmod>2025-08-26T23:47:37+00:00</lastmod>
     <priority>0.80</priority>
   </url>


### PR DESCRIPTION
## Summary
- update the integration tiles and navigation links so Shopify uses the correctly cased HTML file and GoHighLevel points at the live PHP route
- refresh sitemap entries and Netlify redirects to remove stale .html slugs and target the existing integration endpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cb6d20912083339f8d4b9161aec399