### PR TITLE
Fix support form submission endpoint

### DIFF
--- a/index.php
+++ b/index.php
@@ -461,7 +461,7 @@ document.addEventListener('DOMContentLoaded', () => {
     submitBtn.innerHTML = '<span class="loader"></span> Sending...';
     supportOut.textContent = '';
     try {
-      const response = await fetch('support.html', { method: 'POST', body: formData });
+      const response = await fetch('support.php', { method: 'POST', body: formData });
       if (!response.ok) throw new Error('Network response was not ok');
       const result = await response.json();
       if (result.success) {


### PR DESCRIPTION
## Summary
- point the support form submission to the PHP handler instead of the static HTML placeholder

## Testing
- npm test
- Playwright script to submit the support form modal and confirm success message

------
https://chatgpt.com/codex/tasks/task_b_68cb70eeaaac8333b9c6f35bd88fdc2d