### PR TITLE
Adjust hero headline formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,8 +356,8 @@
       <div class="grid md:grid-cols-2 gap-10 items-center">
         <div class="space-y-6 text-left">
           <h1 class="text-3xl sm:text-4xl tracking-tight leading-tight text-white">
-            <span class="uppercase font-ubuntu">PAYMENTS ANYWHERE. GROWTH EVERYWHERE.</span>
-            <span id="animated-headline-sub" class="grad-text-static text-2xl sm:text-3xl font-ubuntu block sm:inline-block mt-2 sm:mt-0 h-10 sm:h-auto">Engineered for speed, secured for trust, and designed to scale..</span>
+            <span class="uppercase font-ubuntu">PAYMENTS ANYWHERE - GROWTH EVERYWHERE</span>
+            <span id="animated-headline-sub" class="grad-text-static text-2xl sm:text-3xl font-ubuntu inline sm:inline sm:ml-2">Engineered for speed, secured for trust, and designed to scale.</span>
           </h1>
           <p class="text-lg text-gray-200 dark:text-slate-300 font-inter text-justify" style="font-weight:100">Effortlessly create your business profile and start accepting payments in minutes—cards, ACH, and secure pay links across online, in-store, and mobile. Lower your costs, onboard quickly, track performance in real time, and protect your business with advanced fraud and chargeback tools.</p>
         </div>


### PR DESCRIPTION
## Summary
- update the hero headline copy to use a hyphen so the phrases render as a continuous paragraph
- keep the supporting tagline inline with the headline and remove the duplicate period

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d179dd43588333be039d30b6985bba