### PR TITLE
Embed ChatBot widget in custom container

### DIFF
--- a/index.html
+++ b/index.html
@@ -1188,13 +1188,18 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     </script>
 <!-- Start of ChatBot (www.chatbot.com) code -->
+<div id="chat-widget-container"></div>
 <script>
   window.__ow = window.__ow || {};
   window.__ow.organizationId = "ded96f09-612d-4fa3-b3e8-014830167318";
   window.__ow.template_id = "55371eae-5b93-456c-8cce-7469ed556849";
   window.__ow.integration_name = "manual_settings";
-  window.__ow.product_name = "chatbot";   
+  window.__ow.product_name = "chatbot";
+  window.__ow.custom_container = document.getElementById('chat-widget-container');
   ;(function(n,t,c){function i(n){return e._h?e._h.apply(null,n):e._q.push(n)}var e={_q:[],_h:null,_v:"2.0",on:function(){i(["on",c.call(arguments)])},once:function(){i(["once",c.call(arguments)])},off:function(){i(["off",c.call(arguments)])},get:function(){if(!e._h)throw new Error("[OpenWidget] You can't use getters before load.");return i(["get",c.call(arguments)])},call:function(){i(["call",c.call(arguments)])},init:function(){var n=t.createElement("script");n.async=!0,n.type="text/javascript",n.src="https://cdn.openwidget.com/openwidget.js",t.head.appendChild(n)}};!n.__ow.asyncInit&&e.init(),n.OpenWidget=n.OpenWidget||e}(window,document,[].slice))
+  OpenWidget.on('ready', function () {
+    OpenWidget.call('maximize');
+  });
 </script>
 <noscript>You need to <a href="https://www.chatbot.com/help/chat-widget/enable-javascript-in-your-browser/" rel="noopener nofollow">enable JavaScript</a> in order to use the AI chatbot tool powered by <a href="https://www.chatbot.com/" rel="noopener nofollow" target="_blank">ChatBot</a></noscript>
 <!-- End of ChatBot code -->


### PR DESCRIPTION
## Summary
- add a dedicated chat widget container div to host the OpenWidget bubble
- configure the OpenWidget initialization to use the custom container and auto-maximize on readiness

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d68e92b7488330b3b80031e36f92dc