### PR TITLE
Add Netlify-ready support contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -487,7 +487,18 @@
       <button class="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" data-close aria-label="Close"><i data-lucide="x" class="h-5 w-5"></i></button>
     </div>
     <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Have a question? Fill out the form below or contact us at <a href="tel:15056006042" class="text-brand-crimson dark:text-brand-teal hover:underline">1-505-600-6042</a>.</p>
-    <form id="support-form" class="mt-4 grid gap-3">
+    <form
+      id="support-form"
+      name="contact"
+      method="POST"
+      data-netlify="true"
+      netlify-honeypot="bot-field"
+      class="mt-4 grid gap-3"
+    >
+      <input type="hidden" name="form-name" value="contact">
+      <p class="hidden">
+        <label>Don’t fill this out: <input name="bot-field"></label>
+      </p>
       <input name="name" placeholder="Your name" class="field rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-3 py-2" required>
       <input name="email" type="email" placeholder="Work email" class="field rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-3 py-2" required>
       <textarea name="message" placeholder="Your message..." rows="4" class="field rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-3 py-2" required></textarea>
@@ -780,16 +791,18 @@ document.addEventListener('DOMContentLoaded', () => {
     submitBtn.innerHTML = '<span class="loader"></span> Sending...';
     supportOut.textContent = '';
     try {
-      const response = await fetch('support.php', { method: 'POST', body: formData });
-      if (!response.ok) throw new Error('Network response was not ok');
-      const result = await response.json();
-      if (result.success) {
-        supportOut.style.color = 'green';
-        supportOut.textContent = 'Message sent successfully!';
-        supportForm.reset();
-      } else {
-        throw new Error(result.message || 'An unknown error occurred.');
+      if (!formData.get('form-name')) {
+        formData.append('form-name', supportForm.getAttribute('name') || 'contact');
       }
+      const response = await fetch('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(formData).toString()
+      });
+      if (!response.ok) throw new Error('Network response was not ok');
+      supportOut.style.color = 'green';
+      supportOut.textContent = 'Message sent successfully!';
+      supportForm.reset();
     } catch (error) {
       supportOut.style.color = 'red';
       supportOut.textContent = `Error: ${error.message}`;


### PR DESCRIPTION
## Summary
- convert the support modal form into a Netlify-enabled contact form with spam protection
- update the client-side submission handler to post to Netlify and confirm success without reloading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9986eaa2c833094f5becc93d14f6f