### PR TITLE
Standardize Contact Support CTA behavior

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -51,6 +51,7 @@
   </script>
   
   <script src="https://unpkg.com/lucide@latest"></script>
+  <script src="/assets/support.js" defer></script>
 
   <style>
     :root { color-scheme: light dark; }
@@ -246,7 +247,13 @@
                 <a href="#commitment" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Commitment</a>
                 <a href="#limitations" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Limitations</a>
                 <a href="#contact" data-close class="px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Contact</a>
-                <a href="#" data-close class="js-support px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors">Contact Support</a>
+                <a
+                  href="mailto:support@merchanthaus.io"
+                  data-close
+                  class="js-support px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors"
+                  data-cta="contact-support"
+                  data-cta-location="accessibility-popout"
+                >Contact Support</a>
                 <a href="https://retailmanager.merchant.haus" data-close class="sm:hidden block px-4 py-2 rounded-lg hover:bg-brand-600 hover:text-white transition-colors mt-2 pt-2 border-t border-slate-200 dark:border-slate-800">Login</a>
             </nav>
             <div class="mt-4 pt-4 border-t border-slate-200 dark:border-slate-800">
@@ -389,7 +396,12 @@
       </nav>
       <nav class="space-y-2">
         <h3 class="font-semibold font-ubuntu">Support</h3>
-        <a href="#" class="js-support block">Contact Support</a>
+        <a
+          href="mailto:support@merchanthaus.io"
+          class="js-support block"
+          data-cta="contact-support"
+          data-cta-location="footer"
+        >Contact Support</a>
         <a href="#faq-question" class="block">FAQs</a>
       </nav>
       <nav class="space-y-2">

--- a/apply.html
+++ b/apply.html
@@ -44,6 +44,9 @@
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 
+    <!-- Support CTA Handler -->
+    <script src="/assets/support.js" defer></script>
+
     <!-- Custom Styles -->
     <style>
         html {
@@ -198,7 +201,12 @@
                      </div>
                      <div class="space-y-2">
                          <h4 class="text-sm font-semibold text-brand-teal uppercase tracking-[0.2em]">Support</h4>
-                         <a href="mailto:support@merchanthaus.io" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Contact Support</a>
+                         <a
+                             href="mailto:support@merchanthaus.io"
+                             class="js-support block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal"
+                             data-cta="contact-support"
+                             data-cta-location="mobile-nav"
+                         >Contact Support</a>
                          <a href="/faq.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">FAQ</a>
                      </div>
                      <div class="space-y-2">
@@ -395,7 +403,12 @@
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Support</h3>
-                <a href="mailto:support@merchanthaus.io" class="block text-slate-300 hover:text-brand-teal">Contact Support</a>
+                <a
+                    href="mailto:support@merchanthaus.io"
+                    class="js-support block text-slate-300 hover:text-brand-teal"
+                    data-cta="contact-support"
+                    data-cta-location="footer"
+                >Contact Support</a>
                 <a href="/faq.html" class="block text-slate-300 hover:text-brand-teal">FAQ</a>
             </nav>
             <nav class="space-y-2">

--- a/assets/support.js
+++ b/assets/support.js
@@ -1,0 +1,218 @@
+/* MerchantHaus support CTA + modal handler */
+(function() {
+  const SUPPORT_EMAIL = 'support@merchanthaus.io';
+  const MAILTO_SUBJECT = encodeURIComponent('Merchant Haus Support Request');
+  const MAILTO_BODY = encodeURIComponent('Hi Merchant Haus Support,\n\nI need assistance with: ');
+  const MAILTO_URL = `mailto:${SUPPORT_EMAIL}?subject=${MAILTO_SUBJECT}&body=${MAILTO_BODY}`;
+  const CTA_SELECTOR = '[data-cta="contact-support"]';
+  let cachedModal = null;
+  let escapeListenerAttached = false;
+
+  const onReady = (fn) => {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn, { once: true });
+    } else {
+      fn();
+    }
+  };
+
+  function dispatchAnalytics(target) {
+    try {
+      const detail = {
+        event: 'contact_support_click',
+        location: target.getAttribute('data-cta-location') || null,
+        text: target.textContent ? target.textContent.trim() : null
+      };
+      window.dispatchEvent(new CustomEvent('mh:analytics', { detail }));
+    } catch (error) {
+      console.warn('Support CTA analytics dispatch failed', error);
+    }
+  }
+
+  function closeModal(modal) {
+    if (!modal) return;
+    modal.classList.add('hidden');
+  }
+
+  function attachFormHandler(modal) {
+    const form = modal.querySelector('#support-form');
+    const errorEl = modal.querySelector('#support-error');
+    if (!form || form.dataset.supportBound === 'true') return;
+
+    form.dataset.supportBound = 'true';
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const submitButton = form.querySelector('button[type="submit"]');
+      const formData = new FormData(form);
+      const originalLabel = submitButton ? submitButton.innerHTML : '';
+
+      if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.innerHTML = '<span class="loader"></span> Sending...';
+      }
+      if (errorEl) {
+        errorEl.textContent = '';
+        errorEl.classList.add('hidden');
+      }
+
+      if (!formData.get('form-name')) {
+        formData.append('form-name', form.getAttribute('name') || 'contact');
+      }
+
+      try {
+        const response = await fetch('/', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams(formData).toString()
+        });
+        if (!response.ok) throw new Error('Network response was not ok');
+        window.location.href = '/thankyou.html';
+      } catch (error) {
+        if (errorEl) {
+          errorEl.textContent = `Error: ${error.message}`;
+          errorEl.classList.remove('hidden');
+        }
+      } finally {
+        if (submitButton) {
+          submitButton.disabled = false;
+          submitButton.innerHTML = originalLabel;
+        }
+      }
+    });
+  }
+
+  function attachModalEvents(modal) {
+    if (!modal || modal.dataset.supportInitialized === 'true') return;
+
+    modal.dataset.supportInitialized = 'true';
+
+    const hide = () => closeModal(modal);
+
+    modal.querySelectorAll('[data-close]').forEach((el) => {
+      el.addEventListener('click', hide);
+    });
+
+    modal.addEventListener('click', (event) => {
+      if (event.target && event.target.dataset && event.target.dataset.close !== undefined) {
+        hide();
+      }
+    });
+
+    if (!escapeListenerAttached) {
+      escapeListenerAttached = true;
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && modal && !modal.classList.contains('hidden')) {
+          hide();
+        }
+      });
+    }
+
+    attachFormHandler(modal);
+  }
+
+  function injectModal() {
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = `
+      <div id="support-modal" class="fixed inset-0 z-[70] hidden">
+        <div class="absolute inset-0 bg-black/60" data-close></div>
+        <div class="mx-auto mt-[10vh] w-[min(560px,92vw)] rounded-2xl bg-white dark:bg-slate-900 p-6 border border-slate-200 dark:border-slate-800 shadow-2xl">
+          <div class="flex items-center justify-between">
+            <h3 class="text-xl font-extrabold font-ubuntu">Contact Support</h3>
+            <button class="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" data-close aria-label="Close">
+              <i data-lucide="x" class="h-5 w-5"></i>
+            </button>
+          </div>
+          <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">
+            Have a question? Fill out the form below or contact us at
+            <a href="tel:15056006042" class="text-brand-crimson dark:text-brand-teal hover:underline">1-505-600-6042</a>.
+          </p>
+          <form
+            id="support-form"
+            name="contact"
+            method="POST"
+            data-netlify="true"
+            netlify-honeypot="bot-field"
+            class="mt-4 grid gap-3"
+          >
+            <input type="hidden" name="form-name" value="contact">
+            <p class="hidden">
+              <label>Don’t fill this out: <input name="bot-field"></label>
+            </p>
+            <input name="name" placeholder="Your name" class="field rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-3 py-2" required>
+            <input name="email" type="email" placeholder="Work email" class="field rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-3 py-2" required>
+            <textarea name="message" placeholder="Your message..." rows="4" class="field rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-3 py-2" required></textarea>
+            <button class="rounded-lg bg-brand-crimson text-white font-semibold px-4 py-2 hover:bg-brand-crimson" type="submit">Send Message</button>
+            <p id="support-error" class="text-xs text-red-500 hidden" role="alert" aria-live="polite"></p>
+          </form>
+        </div>
+      </div>
+    `;
+    return wrapper.firstElementChild;
+  }
+
+  function ensureModal() {
+    if (cachedModal && document.body.contains(cachedModal)) {
+      return cachedModal;
+    }
+
+    const existing = document.getElementById('support-modal');
+    if (existing) {
+      cachedModal = existing;
+      attachModalEvents(cachedModal);
+      if (window.lucide && lucide.createIcons) {
+        try { lucide.createIcons(); } catch (error) { console.warn('Lucide render failed', error); }
+      }
+      return cachedModal;
+    }
+
+    const injected = injectModal();
+    if (!injected) return null;
+    document.body.appendChild(injected);
+    cachedModal = injected;
+    attachModalEvents(cachedModal);
+    if (window.lucide && lucide.createIcons) {
+      try { lucide.createIcons(); } catch (error) { console.warn('Lucide render failed', error); }
+    }
+    return cachedModal;
+  }
+
+  function openModal() {
+    const modal = ensureModal();
+    if (!modal) return false;
+    modal.classList.remove('hidden');
+    const focusTarget = modal.querySelector('input[name="name"]');
+    if (focusTarget) {
+      focusTarget.focus({ preventScroll: true });
+    }
+    return true;
+  }
+
+  function bindCta(element) {
+    if (!element || element.dataset.supportCtaBound === 'true') return;
+
+    element.dataset.supportCtaBound = 'true';
+    const tag = element.tagName.toLowerCase();
+    if (tag === 'a' && !element.getAttribute('href')) {
+      element.setAttribute('href', MAILTO_URL);
+    }
+
+    element.addEventListener('click', (event) => {
+      dispatchAnalytics(element);
+      const modalOpened = openModal();
+      if (modalOpened) {
+        event.preventDefault();
+      } else if (tag !== 'a') {
+        window.location.href = MAILTO_URL;
+      }
+    });
+  }
+
+  onReady(() => {
+    document.querySelectorAll(CTA_SELECTOR).forEach(bindCta);
+    const existing = document.getElementById('support-modal');
+    if (existing) {
+      cachedModal = existing;
+      attachModalEvents(existing);
+    }
+  });
+})();

--- a/compliance.html
+++ b/compliance.html
@@ -44,6 +44,9 @@
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 
+    <!-- Support CTA Handler -->
+    <script src="/assets/support.js" defer></script>
+
     <!-- Custom Styles -->
     <style>
         html {
@@ -198,7 +201,12 @@
                      </div>
                      <div class="space-y-2">
                          <h4 class="text-sm font-semibold text-brand-teal uppercase tracking-[0.2em]">Support</h4>
-                         <a href="mailto:support@merchanthaus.io" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Contact Support</a>
+                         <a
+                             href="mailto:support@merchanthaus.io"
+                             class="js-support block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal"
+                             data-cta="contact-support"
+                             data-cta-location="mobile-nav"
+                         >Contact Support</a>
                          <a href="/faq.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">FAQ</a>
                      </div>
                      <div class="space-y-2">
@@ -388,14 +396,6 @@
                 });
             }
 
-            const supportModal = document.getElementById('support-modal');
-            document.querySelectorAll('.js-support').forEach(el => {
-                el.addEventListener('click', (e) => { e.preventDefault(); if(supportModal) supportModal.classList.remove('hidden'); });
-            });
-            if(supportModal) supportModal.addEventListener('click', (e) => {
-                if (e.target.dataset.close !== undefined) supportModal.classList.add('hidden');
-            });
-            
             // --- Application Form JavaScript ---
             const states = ["Alabama","Alaska","Arizona","Arkansas","California","Colorado","Connecticut","Delaware","District of Columbia","Florida","Georgia","Hawaii","Idaho","Illinois","Indiana","Iowa","Kansas","Kentucky","Louisiana","Maine","Maryland","Massachusetts","Michigan","Minnesota","Mississippi","Missouri","Montana","Nebraska","Nevada","New Hampshire","New Jersey","New Mexico","New York","North Carolina","North Dakota","Ohio","Oklahoma","Oregon","Pennsylvania","Rhode Island","South Carolina","South Dakota","Tennessee","Texas","Utah","Vermont","Virginia","Washington","West Virginia","Wisconsin","Wyoming"];
             const stateSelect = document.querySelector('select[name="state"]');
@@ -474,7 +474,12 @@
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Support</h3>
-                <a href="mailto:support@merchanthaus.io" class="block text-slate-300 hover:text-brand-teal">Contact Support</a>
+                <a
+                    href="mailto:support@merchanthaus.io"
+                    class="js-support block text-slate-300 hover:text-brand-teal"
+                    data-cta="contact-support"
+                    data-cta-location="footer"
+                >Contact Support</a>
                 <a href="/faq.html" class="block text-slate-300 hover:text-brand-teal">FAQ</a>
             </nav>
             <nav class="space-y-2">

--- a/faq.html
+++ b/faq.html
@@ -44,6 +44,9 @@
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 
+    <!-- Support CTA Handler -->
+    <script src="/assets/support.js" defer></script>
+
     <!-- Custom Styles -->
     <style>
         html {
@@ -198,7 +201,12 @@
                      </div>
                      <div class="space-y-2">
                          <h4 class="text-sm font-semibold text-brand-teal uppercase tracking-[0.2em]">Support</h4>
-                         <a href="mailto:support@merchanthaus.io" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Contact Support</a>
+                         <a
+                             href="mailto:support@merchanthaus.io"
+                             class="js-support block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal"
+                             data-cta="contact-support"
+                             data-cta-location="mobile-nav"
+                         >Contact Support</a>
                          <a href="/faq.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">FAQ</a>
                      </div>
                      <div class="space-y-2">
@@ -342,7 +350,12 @@
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Support</h3>
-                <a href="mailto:support@merchanthaus.io" class="block text-slate-300 hover:text-brand-teal">Contact Support</a>
+                <a
+                    href="mailto:support@merchanthaus.io"
+                    class="js-support block text-slate-300 hover:text-brand-teal"
+                    data-cta="contact-support"
+                    data-cta-location="footer"
+                >Contact Support</a>
                 <a href="/faq.html" class="block text-slate-300 hover:text-brand-teal">FAQ</a>
             </nav>
             <nav class="space-y-2">

--- a/gohighlevel.html
+++ b/gohighlevel.html
@@ -44,6 +44,9 @@
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 
+    <!-- Support CTA Handler -->
+    <script src="/assets/support.js" defer></script>
+
     <!-- Custom Styles -->
     <style>
         html {
@@ -198,7 +201,12 @@
                      </div>
                      <div class="space-y-2">
                          <h4 class="text-sm font-semibold text-brand-teal uppercase tracking-[0.2em]">Support</h4>
-                         <a href="mailto:support@merchanthaus.io" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Contact Support</a>
+                         <a
+                             href="mailto:support@merchanthaus.io"
+                             class="js-support block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal"
+                             data-cta="contact-support"
+                             data-cta-location="mobile-nav"
+                         >Contact Support</a>
                          <a href="/faq.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">FAQ</a>
                      </div>
                      <div class="space-y-2">
@@ -344,7 +352,12 @@
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Support</h3>
-                <a href="mailto:support@merchanthaus.io" class="block text-slate-300 hover:text-brand-teal">Contact Support</a>
+                <a
+                    href="mailto:support@merchanthaus.io"
+                    class="js-support block text-slate-300 hover:text-brand-teal"
+                    data-cta="contact-support"
+                    data-cta-location="footer"
+                >Contact Support</a>
                 <a href="/faq.html" class="block text-slate-300 hover:text-brand-teal">FAQ</a>
             </nav>
             <nav class="space-y-2">

--- a/index.html
+++ b/index.html
@@ -44,6 +44,9 @@
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 
+    <!-- Support CTA Handler -->
+    <script src="/assets/support.js" defer></script>
+
     <!-- Custom Styles -->
     <style>
         html {
@@ -193,7 +196,12 @@
                     </div>
                     <div class="space-y-2">
                         <h4 class="text-sm font-semibold text-brand-teal uppercase tracking-[0.2em]">Support</h4>
-                        <a href="mailto:support@merchanthaus.io" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Contact Support</a>
+                        <a
+                          href="mailto:support@merchanthaus.io"
+                          class="js-support block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal"
+                          data-cta="contact-support"
+                          data-cta-location="mobile-nav"
+                        >Contact Support</a>
                         <a href="/faq.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">FAQ</a>
                     </div>
                     <div class="space-y-2">
@@ -368,7 +376,12 @@
             <div id="hero-actions" class="flex flex-wrap justify-center items-center gap-3">
               <button class="js-signup-cta bg-transparent hover:bg-brand-crimson text-brand-crimson hover:text-white border border-brand-crimson px-4 py-2 rounded-full text-sm font-semibold transition-colors duration-300">Get Started</button>
               <button class="bg-slate-100/20 dark:bg-slate-800/30 text-white px-4 py-2 rounded-full text-sm font-medium hover:bg-slate-200/30 dark:hover:bg-slate-700/40 transition-colors">Chargeback Help</button>
-              <button class="js-support bg-slate-100/20 dark:bg-slate-800/30 text-white px-4 py-2 rounded-full text-sm font-medium hover:bg-slate-200/30 dark:hover:bg-slate-700/40 transition-colors">Contact Support</button>
+              <button
+                type="button"
+                class="js-support bg-slate-100/20 dark:bg-slate-800/30 text-white px-4 py-2 rounded-full text-sm font-medium hover:bg-slate-200/30 dark:hover:bg-slate-700/40 transition-colors"
+                data-cta="contact-support"
+                data-cta-location="hero"
+              >Contact Support</button>
             </div>
             <div id="faq-answer" class="mt-6 p-4 text-left rounded-lg bg-white/90 dark:bg-slate-900/90 border border-slate-200 dark:border-slate-800 text-slate-800 dark:text-slate-200"></div>
           </div>
@@ -636,16 +649,6 @@ document.addEventListener('DOMContentLoaded', () => {
         integrationsTrack.appendChild(item);
     });
   }
-
-
-  const supportModal = document.getElementById('support-modal');
-  document.querySelectorAll('.js-support').forEach(el => {
-    el.addEventListener('click', (e) => { e.preventDefault(); supportModal.classList.remove('hidden'); });
-  });
-  supportModal.addEventListener('click', (e) => {
-    if (e.target.dataset.close !== undefined) supportModal.classList.add('hidden');
-  });
-
   const headingTexts = { "integrations-old": "Integrate with Your Favorite Tools" }; // Old logic, can be removed or updated
   const headingObserver = new IntersectionObserver((entries, observer) => {
     entries.forEach(entry => {
@@ -785,41 +788,6 @@ document.addEventListener('DOMContentLoaded', () => {
   askFaqBtn.addEventListener('click', handleFaqSubmit);
   faqQuestionInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') handleFaqSubmit(); });
 
-  const supportForm = document.getElementById('support-form');
-  const supportError = document.getElementById('support-error');
-  supportForm.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const formData = new FormData(supportForm);
-    const submitBtn = supportForm.querySelector('button[type="submit"]');
-    const originalBtnText = submitBtn.innerHTML;
-    submitBtn.disabled = true;
-    submitBtn.innerHTML = '<span class="loader"></span> Sending...';
-    if (supportError) {
-      supportError.textContent = '';
-      supportError.classList.add('hidden');
-    }
-    try {
-      if (!formData.get('form-name')) {
-        formData.append('form-name', supportForm.getAttribute('name') || 'contact');
-      }
-      const response = await fetch('/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams(formData).toString()
-      });
-      if (!response.ok) throw new Error('Network response was not ok');
-      window.location.href = '/thankyou.html';
-    } catch (error) {
-      if (supportError) {
-        supportError.textContent = `Error: ${error.message}`;
-        supportError.classList.remove('hidden');
-      }
-    } finally {
-      submitBtn.disabled = false;
-      submitBtn.innerHTML = originalBtnText;
-    }
-  });
-
   // --- APPLICATION FORM LOGIC ---
   const applyForm = document.getElementById('apply-form');
   if (applyForm) {
@@ -923,7 +891,12 @@ document.addEventListener('DOMContentLoaded', () => {
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Support</h3>
-                <a href="mailto:support@merchanthaus.io" class="block text-slate-300 hover:text-brand-teal">Contact Support</a>
+                <a
+                  href="mailto:support@merchanthaus.io"
+                  class="js-support block text-slate-300 hover:text-brand-teal"
+                  data-cta="contact-support"
+                  data-cta-location="footer"
+                >Contact Support</a>
                 <a href="/faq.html" class="block text-slate-300 hover:text-brand-teal">FAQ</a>
             </nav>
             <nav class="space-y-2">

--- a/integrations/gohighlevel.html
+++ b/integrations/gohighlevel.html
@@ -44,6 +44,9 @@
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 
+    <!-- Support CTA Handler -->
+    <script src="/assets/support.js" defer></script>
+
     <!-- Custom Styles -->
     <style>
         html {
@@ -198,7 +201,12 @@
                      </div>
                      <div class="space-y-2">
                          <h4 class="text-sm font-semibold text-brand-teal uppercase tracking-[0.2em]">Support</h4>
-                         <a href="mailto:support@merchanthaus.io" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Contact Support</a>
+                         <a
+                             href="mailto:support@merchanthaus.io"
+                             class="js-support block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal"
+                             data-cta="contact-support"
+                             data-cta-location="mobile-nav"
+                         >Contact Support</a>
                          <a href="/faq.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">FAQ</a>
                      </div>
                      <div class="space-y-2">
@@ -344,7 +352,12 @@
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Support</h3>
-                <a href="mailto:support@merchanthaus.io" class="block text-slate-300 hover:text-brand-teal">Contact Support</a>
+                <a
+                    href="mailto:support@merchanthaus.io"
+                    class="js-support block text-slate-300 hover:text-brand-teal"
+                    data-cta="contact-support"
+                    data-cta-location="footer"
+                >Contact Support</a>
                 <a href="/faq.html" class="block text-slate-300 hover:text-brand-teal">FAQ</a>
             </nav>
             <nav class="space-y-2">

--- a/integrations/index.html
+++ b/integrations/index.html
@@ -44,6 +44,9 @@
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 
+    <!-- Support CTA Handler -->
+    <script src="/assets/support.js" defer></script>
+
     <!-- Custom Styles -->
     <style>
         html {
@@ -198,7 +201,12 @@
                      </div>
                      <div class="space-y-2">
                          <h4 class="text-sm font-semibold text-brand-teal uppercase tracking-[0.2em]">Support</h4>
-                         <a href="mailto:support@merchanthaus.io" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Contact Support</a>
+                         <a
+                             href="mailto:support@merchanthaus.io"
+                             class="js-support block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal"
+                             data-cta="contact-support"
+                             data-cta-location="mobile-nav"
+                         >Contact Support</a>
                          <a href="/faq.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">FAQ</a>
                      </div>
                      <div class="space-y-2">
@@ -603,7 +611,12 @@
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Support</h3>
-                <a href="mailto:support@merchanthaus.io" class="block text-slate-300 hover:text-brand-teal">Contact Support</a>
+                <a
+                    href="mailto:support@merchanthaus.io"
+                    class="js-support block text-slate-300 hover:text-brand-teal"
+                    data-cta="contact-support"
+                    data-cta-location="footer"
+                >Contact Support</a>
                 <a href="/faq.html" class="block text-slate-300 hover:text-brand-teal">FAQ</a>
             </nav>
             <nav class="space-y-2">

--- a/integrations/shopify.html
+++ b/integrations/shopify.html
@@ -44,6 +44,9 @@
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 
+    <!-- Support CTA Handler -->
+    <script src="/assets/support.js" defer></script>
+
     <!-- Custom Styles -->
     <style>
         html {
@@ -198,7 +201,12 @@
                      </div>
                      <div class="space-y-2">
                          <h4 class="text-sm font-semibold text-brand-teal uppercase tracking-[0.2em]">Support</h4>
-                         <a href="mailto:support@merchanthaus.io" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Contact Support</a>
+                         <a
+                             href="mailto:support@merchanthaus.io"
+                             class="js-support block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal"
+                             data-cta="contact-support"
+                             data-cta-location="mobile-nav"
+                         >Contact Support</a>
                          <a href="/faq.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">FAQ</a>
                      </div>
                      <div class="space-y-2">
@@ -344,7 +352,12 @@
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Support</h3>
-                <a href="mailto:support@merchanthaus.io" class="block text-slate-300 hover:text-brand-teal">Contact Support</a>
+                <a
+                    href="mailto:support@merchanthaus.io"
+                    class="js-support block text-slate-300 hover:text-brand-teal"
+                    data-cta="contact-support"
+                    data-cta-location="footer"
+                >Contact Support</a>
                 <a href="/faq.html" class="block text-slate-300 hover:text-brand-teal">FAQ</a>
             </nav>
             <nav class="space-y-2">

--- a/privacy.html
+++ b/privacy.html
@@ -44,6 +44,9 @@
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 
+    <!-- Support CTA Handler -->
+    <script src="/assets/support.js" defer></script>
+
     <!-- Custom Styles -->
     <style>
         html {
@@ -198,7 +201,12 @@
                      </div>
                      <div class="space-y-2">
                          <h4 class="text-sm font-semibold text-brand-teal uppercase tracking-[0.2em]">Support</h4>
-                         <a href="mailto:support@merchanthaus.io" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Contact Support</a>
+                         <a
+                             href="mailto:support@merchanthaus.io"
+                             class="js-support block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal"
+                             data-cta="contact-support"
+                             data-cta-location="mobile-nav"
+                         >Contact Support</a>
                          <a href="/faq.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">FAQ</a>
                      </div>
                      <div class="space-y-2">
@@ -408,7 +416,12 @@
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Support</h3>
-                <a href="mailto:support@merchanthaus.io" class="block text-slate-300 hover:text-brand-teal">Contact Support</a>
+                <a
+                    href="mailto:support@merchanthaus.io"
+                    class="js-support block text-slate-300 hover:text-brand-teal"
+                    data-cta="contact-support"
+                    data-cta-location="footer"
+                >Contact Support</a>
                 <a href="/faq.html" class="block text-slate-300 hover:text-brand-teal">FAQ</a>
             </nav>
             <nav class="space-y-2">

--- a/shopify.html
+++ b/shopify.html
@@ -44,6 +44,9 @@
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 
+    <!-- Support CTA Handler -->
+    <script src="/assets/support.js" defer></script>
+
     <!-- Custom Styles -->
     <style>
         html {
@@ -198,7 +201,12 @@
                      </div>
                      <div class="space-y-2">
                          <h4 class="text-sm font-semibold text-brand-teal uppercase tracking-[0.2em]">Support</h4>
-                         <a href="mailto:support@merchanthaus.io" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Contact Support</a>
+                         <a
+                             href="mailto:support@merchanthaus.io"
+                             class="js-support block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal"
+                             data-cta="contact-support"
+                             data-cta-location="mobile-nav"
+                         >Contact Support</a>
                          <a href="/faq.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">FAQ</a>
                      </div>
                      <div class="space-y-2">
@@ -712,7 +720,12 @@
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Support</h3>
-                <a href="mailto:support@merchanthaus.io" class="block text-slate-300 hover:text-brand-teal">Contact Support</a>
+                <a
+                    href="mailto:support@merchanthaus.io"
+                    class="js-support block text-slate-300 hover:text-brand-teal"
+                    data-cta="contact-support"
+                    data-cta-location="footer"
+                >Contact Support</a>
                 <a href="/faq.html" class="block text-slate-300 hover:text-brand-teal">FAQ</a>
             </nav>
             <nav class="space-y-2">

--- a/src/includes/footer.php
+++ b/src/includes/footer.php
@@ -21,7 +21,12 @@
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Support</h3>
-                <a href="mailto:support@merchanthaus.io" class="block text-slate-300 hover:text-brand-teal">Contact Support</a>
+                <a
+                    href="mailto:support@merchanthaus.io"
+                    class="js-support block text-slate-300 hover:text-brand-teal"
+                    data-cta="contact-support"
+                    data-cta-location="footer"
+                >Contact Support</a>
                 <a href="/faq.html" class="block text-slate-300 hover:text-brand-teal">FAQ</a>
             </nav>
             <nav class="space-y-2">
@@ -41,6 +46,8 @@
         <span class="sr-only">Back to top</span>
     </button>
 
+
+    <script src="/assets/support.js" defer></script>
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/terms.html
+++ b/terms.html
@@ -44,6 +44,9 @@
     <!-- Lucide Icons -->
     <script src="https://unpkg.com/lucide@latest"></script>
 
+    <!-- Support CTA Handler -->
+    <script src="/assets/support.js" defer></script>
+
     <!-- Custom Styles -->
     <style>
         html {
@@ -198,7 +201,12 @@
                      </div>
                      <div class="space-y-2">
                          <h4 class="text-sm font-semibold text-brand-teal uppercase tracking-[0.2em]">Support</h4>
-                         <a href="mailto:support@merchanthaus.io" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">Contact Support</a>
+                         <a
+                             href="mailto:support@merchanthaus.io"
+                             class="js-support block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal"
+                             data-cta="contact-support"
+                             data-cta-location="mobile-nav"
+                         >Contact Support</a>
                          <a href="/faq.html" class="block w-full px-4 py-2 text-left rounded-full border border-brand-teal bg-[#262626] text-white transition-colors duration-200 hover:bg-brand-teal">FAQ</a>
                      </div>
                      <div class="space-y-2">
@@ -421,7 +429,12 @@
             </nav>
             <nav class="space-y-2">
                 <h3 class="font-semibold font-ubuntu text-white">Support</h3>
-                <a href="mailto:support@merchanthaus.io" class="block text-slate-300 hover:text-brand-teal">Contact Support</a>
+                <a
+                    href="mailto:support@merchanthaus.io"
+                    class="js-support block text-slate-300 hover:text-brand-teal"
+                    data-cta="contact-support"
+                    data-cta-location="footer"
+                >Contact Support</a>
                 <a href="/faq.html" class="block text-slate-300 hover:text-brand-teal">FAQ</a>
             </nav>
             <nav class="space-y-2">


### PR DESCRIPTION
## Summary
- add a shared support.js helper to inject/drive the contact support modal, analytics event, and Netlify submission
- tag every Contact Support CTA with consistent data attributes across navigation and footers
- load the shared handler from HTML templates and the PHP footer include while removing page-specific listeners

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9a0010d208330a118272d31d11ed7