### PR TITLE
Fix header logo clipping

### DIFF
--- a/accessibility.html
+++ b/accessibility.html
@@ -606,7 +606,7 @@
         </style>
       </defs>
 
-      <image href="Shield/Shield.png" x="10" y="10" height="80" width="80" />
+      <image href="Shield/Shield.png" x="12" y="6" height="76" width="76" />
 
       <g class="mh-wordmark" fill="url(#mhGradient)" shape-rendering="geometricPrecision" text-rendering="optimizeLegibility">
         <text x="120" y="45">MerchantHaus</text>

--- a/apply.html
+++ b/apply.html
@@ -468,7 +468,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/compliance.html
+++ b/compliance.html
@@ -539,7 +539,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/faq.html
+++ b/faq.html
@@ -415,7 +415,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/gohighlevel.html
+++ b/gohighlevel.html
@@ -417,7 +417,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/index.html
+++ b/index.html
@@ -968,7 +968,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/integrations.html
+++ b/integrations.html
@@ -668,7 +668,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/integrations/gohighlevel.html
+++ b/integrations/gohighlevel.html
@@ -417,7 +417,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/integrations/index.html
+++ b/integrations/index.html
@@ -676,7 +676,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/integrations/shopify.html
+++ b/integrations/shopify.html
@@ -417,7 +417,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/privacy.html
+++ b/privacy.html
@@ -481,7 +481,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/shopify.html
+++ b/shopify.html
@@ -385,7 +385,7 @@
                      <div class="grid md:grid-cols-2 items-center gap-8 mb-8">
                          <div class="flex justify-center md:justify-end">
                             <svg width="500" height="100" viewBox="0 0 500 100" xmlns="http://www.w3.org/2000/svg">
-                               <image href="/public/assets/images/Shield.png" x="10" y="10" height="80" width="80" />
+                               <image href="/public/assets/images/Shield.png" x="12" y="6" height="76" width="76" />
                                <g fill="#DC143C" class="dark:fill-white" style="font-family: 'Ubuntu', sans-serif; font-size: 50px; font-weight: 600;">
                                   <text y="60" x="120">MerchantHaus</text>
                                </g>
@@ -785,7 +785,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/src/includes/footer.php
+++ b/src/includes/footer.php
@@ -85,7 +85,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="/public/assets/images/Shield.png" x="10" y="10" height="80" width="80" />
+                    <image href="/public/assets/images/Shield.png" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">

--- a/terms.html
+++ b/terms.html
@@ -494,7 +494,7 @@
                             .mh-tagline-${id} { font-family: 'Inter', sans-serif; font-size: 18px; font-weight: 500; fill: #A9A9A9; text-anchor: middle; letter-spacing: 4px; }
                         </style>
                     </defs>
-                    <image href="${logoImagePath}" x="10" y="10" height="80" width="80" />
+                    <image href="${logoImagePath}" x="12" y="6" height="76" width="76" />
                     <text class="mh-text-${id}" y="60" x="110">${letterTags}</text>
                     ${tagline ? `
                         <line x1="160" x2="400" y1="72" y2="72" stroke="#00CEDB" stroke-width="2" opacity="0">


### PR DESCRIPTION
## Summary
- shrink the shield portion of the inline SVG logo across the static templates so it no longer clips against the header capsule

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68db2bf982e083309c2ed35ccd1a6b98