### PR TITLE
Improve mobile chatbot layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,48 @@
             clip: rect(0,0,0,0);
             border: 0;
         }
+
+        .hero-layout {
+            gap: 2.5rem;
+        }
+
+        @media (max-width: 767px) {
+            .hero-layout {
+                gap: 2rem;
+            }
+
+            .hero-text {
+                text-align: center;
+            }
+
+            .hero-text p {
+                text-align: center;
+            }
+
+            .hero-chat-card {
+                width: 100%;
+                margin: 0 auto;
+                padding: 1.25rem;
+                background-color: rgba(15, 23, 42, 0.35);
+                border-radius: 1.5rem;
+                backdrop-filter: blur(6px);
+            }
+
+            .hero-chat-card .field {
+                font-size: 1rem;
+                padding-top: 0.85rem;
+                padding-bottom: 0.85rem;
+            }
+
+            .hero-chat-card button {
+                transform: scale(0.95);
+            }
+
+            #faq-answer {
+                max-height: 240px;
+                font-size: 0.95rem;
+            }
+        }
     </style>
 
     <!-- Favicons -->
@@ -356,16 +398,16 @@
 <div class="relative">
   <section class="relative overflow-hidden animate-fadeIn hero-bg-container">
     <div class="absolute inset-0 bg-black/50 -z-10"></div>
-    <div class="max-w-7xl mx-auto px-4 pt-16 md:pt-24 pb-28">
-      <div class="grid md:grid-cols-2 gap-10 items-center">
-        <div class="space-y-6 text-left">
+    <div class="max-w-7xl mx-auto px-4 pt-12 sm:pt-16 md:pt-24 pb-20 md:pb-28">
+      <div class="flex flex-col-reverse hero-layout md:grid md:grid-cols-2 md:gap-10 items-center">
+        <div class="space-y-6 text-left hero-text">
           <h1 class="text-3xl sm:text-4xl tracking-tight leading-tight text-white">
             <span class="uppercase font-ubuntu">PAYMENTS ANYWHERE - GROWTH EVERYWHERE</span>
             <span id="animated-headline-sub" class="grad-text-static text-2xl sm:text-3xl font-ubuntu inline sm:inline sm:ml-2">Engineered for speed, secured for trust, and designed to scale.</span>
           </h1>
-          <p class="text-lg text-gray-200 dark:text-slate-300 font-inter text-justify" style="font-weight:100">Effortlessly create your business profile and start accepting payments in minutes—cards, ACH, and secure pay links across online, in-store, and mobile. Lower your costs, onboard quickly, track performance in real time, and protect your business with advanced fraud and chargeback tools.</p>
+          <p class="text-lg text-gray-200 dark:text-slate-300 font-inter text-center md:text-justify" style="font-weight:100">Effortlessly create your business profile and start accepting payments in minutes—cards, ACH, and secure pay links across online, in-store, and mobile. Lower your costs, onboard quickly, track performance in real time, and protect your business with advanced fraud and chargeback tools.</p>
         </div>
-        <div class="relative p-4">
+        <div class="relative p-4 hero-chat-card">
           <div class="w-full space-y-4 relative z-10">
             <div class="relative">
               <input type="text" id="faq-question" placeholder="Ask about pricing, features..." class="field w-full p-4 pr-12 text-lg rounded-full bg-white/20 dark:bg-slate-900/30 border border-slate-300/50 dark:border-slate-700/50 text-white placeholder-slate-300 focus:ring-2 focus:ring-brand-crimson focus:border-transparent transition-all">


### PR DESCRIPTION
## Summary
- Reorder the hero section on mobile so the chatbot card appears before the copy and reduce excess padding for smaller screens
- Add mobile-specific styling for the chatbot card, input, and transcript area to improve readability and fit

## Testing
- No automated tests were run (HTML/CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_68db2c18ca248330af5d7003a0e169b7