### PR TITLE
Speed up integrations marquee

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,7 +325,7 @@
           mask-image: linear-gradient(to right, transparent 0, #000 var(--marquee-fade), #000 calc(100% - var(--marquee-fade)), transparent 100%);
 }
 .marquee-track {
-  animation: marquee-slide-left 45s linear infinite;
+  animation: marquee-slide-left 30s linear infinite;
   will-change: transform;
 }
 .marquee-track--reverse { animation-name: marquee-slide-right; }


### PR DESCRIPTION
## Summary
- shorten the marquee animation duration on the home page integrations section to speed up the scrolling logos

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd86a06fe083308680e8ed3f1d20b5