### PR TITLE
Refine service card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,14 +455,15 @@
         .service-card {
             width: 100%;
             height: 100%;
-            border-radius: 1.25rem;
-            box-shadow: 0 18px 38px rgba(15, 23, 42, 0.35);
+            border-radius: 1rem;
+            background: rgba(255, 255, 255, 0.85);
+            box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
             overflow: hidden;
-            color: #ffffff;
+            color: #1a1a1a;
             font-family: 'Ubuntu', sans-serif;
-            font-weight: 700;
+            font-weight: 600;
             text-align: center;
-            transition: transform 0.35s ease, box-shadow 0.35s ease;
+            transition: transform 0.35s ease, box-shadow 0.35s ease, background 0.35s ease;
             position: relative;
             transform: translateY(-10%);
             --service-image-brightness: 70%;
@@ -470,7 +471,8 @@
         }
         .service-card:hover {
             transform: translateY(calc(-10% - 8px)) scale(1.02);
-            box-shadow: 0 22px 45px rgba(15, 23, 42, 0.45);
+            box-shadow: 0 12px 28px rgba(15, 23, 42, 0.3);
+            background: rgba(255, 255, 255, 0.92);
             --service-image-brightness: 85%;
         }
         .service-image {
@@ -514,40 +516,52 @@
             gap: 0.85rem;
             padding: 2.5rem 1.5rem;
             width: 100%;
-            background: radial-gradient(circle at 50% 30%, rgba(255, 255, 255, 0.35), rgba(15, 23, 42, 0.55));
+            background: radial-gradient(circle at 50% 30%, rgba(255, 255, 255, 0.7), rgba(236, 240, 241, 0.35));
             backdrop-filter: blur(6px);
-            text-shadow: 0 4px 18px rgba(15, 23, 42, 0.65);
+            color: #1a1a1a;
+            text-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
         }
         .service-icon-wrap {
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            padding: 0.85rem;
-            border-radius: 9999px;
-            background: linear-gradient(145deg, rgba(15, 23, 42, 0.9), rgba(2, 132, 199, 0.65));
-            border: 1px solid rgba(255, 255, 255, 0.25);
-            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15), 0 12px 22px rgba(15, 23, 42, 0.45);
+            padding: 0.5rem;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.7);
+            box-shadow: 0 12px 22px rgba(44, 62, 80, 0.18);
             transition: transform 0.35s ease, box-shadow 0.35s ease;
         }
         .service-icon {
-            width: 3.5rem;
-            height: 3.5rem;
-            stroke-width: 1.4;
-            color: #ffffff;
+            width: 2.2rem;
+            height: 2.2rem;
+            stroke-width: 1.5;
+            color: #2c3e50;
         }
         .service-name {
             font-size: 1.2rem;
+            font-weight: 600;
             letter-spacing: 0.01em;
             text-transform: uppercase;
+            text-align: center;
+            margin: 0.25rem 0 0;
             transition: letter-spacing 0.35s ease, transform 0.35s ease;
         }
         .service-card:hover .service-icon-wrap {
             transform: translateY(-6px) scale(1.05);
-            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25), 0 20px 34px rgba(15, 23, 42, 0.6);
+            box-shadow: 0 18px 30px rgba(44, 62, 80, 0.25);
         }
         .service-card:hover .service-name {
             letter-spacing: 0.08em;
             transform: translateY(-2px);
+        }
+        @media (max-width: 768px) {
+            .service-icon {
+                width: 1.8rem;
+                height: 1.8rem;
+            }
+            .service-name {
+                font-size: 1rem;
+            }
         }
         .banner .item:nth-child(1) .service-image { background-image: linear-gradient(rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.1)), url('assets/img/card1.png'); }
         .banner .item:nth-child(2) .service-image { background-image: linear-gradient(rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.1)), url('assets/img/card2.png'); }


### PR DESCRIPTION
## Summary
- soften the service card background with a light, translucent panel and subtler hover shadow
- give icons a dedicated halo, consistent sizing, and neutral stroke for better contrast
- adjust service titles and add mobile scaling to balance typography across viewports

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd89554fb88330affb73685bc9d254