### PR TITLE
feat: add dynamic banner and integration carousels

### DIFF
--- a/assets/banner-carousel.js
+++ b/assets/banner-carousel.js
@@ -1,0 +1,388 @@
+const BANNER_ENDPOINT = '/.netlify/functions/list-assets?type=banner';
+const INTEGRATIONS_ENDPOINT = '/.netlify/functions/list-assets?type=integrations';
+
+const FALLBACK_BANNER_IMAGES = [
+  'card1.png',
+  'card2.png',
+  'card3.png',
+  'card4.png',
+  'card5.png',
+  'card6.png',
+  'card7.png',
+  'card8.png',
+  'card9.png',
+  'card10.png'
+];
+
+const FALLBACK_INTEGRATION_IMAGES = [
+  'bigcommerce.webp',
+  'clover.webp',
+  'freshbooks.webp',
+  'hubspot.webp',
+  'keap.webp',
+  'lightspeed.webp',
+  'magento.webp',
+  'mastercard.webp',
+  'memberpress.svg',
+  'ncr.webp',
+  'quickbooks.webp',
+  'salesforce.webp',
+  'squarespace.webp',
+  'vend.webp',
+  'visa.webp',
+  'wix.webp',
+  'woocommerce.webp',
+  'zoho_crm.webp'
+];
+
+const CARD_DETAILS = {
+  'Mobile Payments': 'Accept tap, chip, and swipe transactions from handheld readers with offline safeguards and instant digital receipts.',
+  'Smart Routing': 'Automatically steer each transaction to the least-cost, highest-approval processor to minimize declines and interchange fees.',
+  'Invoicing': 'Create branded invoices with payment links, automated reminders, and partial payment tracking in a single dashboard.',
+  'Recurring Billing': 'Manage subscriptions and installment plans with smart retries, automated dunning, and flexible billing cadences.',
+  'Secure Tokenization': 'Replace card numbers with vaulted tokens so you can stay PCI compliant while enabling one-click payments everywhere.',
+  'Detailed Reporting': 'Visualize deposits, settlements, disputes, and channel performance with real-time filters and export-ready reports.',
+  'Automation': 'Trigger workflows across your CRM, fulfillment, and accounting tools the moment payments succeed or fail.',
+  'ACH Payments': 'Offer low-cost bank transfers with instant account verification, configurable limits, and automated reconciliation.',
+  'Fraud Prevention': 'Layer device intelligence, risk scoring, and velocity controls to stop fraudsters without blocking good customers.',
+  'Global Payments': 'Launch in new markets with multi-currency pricing, localized payment methods, and dynamic FX management.'
+};
+
+const ready = () => new Promise((resolve) => {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', resolve, { once: true });
+  } else {
+    resolve();
+  }
+});
+
+async function fetchAssetList(endpoint, fallbackFiles, fallbackBasePath) {
+  try {
+    const response = await fetch(endpoint, { headers: { 'Cache-Control': 'no-cache' } });
+    if (!response.ok) throw new Error(`Request failed: ${response.status}`);
+    const payload = await response.json();
+    const files = Array.isArray(payload.files) ? payload.files : [];
+    const basePath = typeof payload.basePath === 'string' ? payload.basePath : fallbackBasePath;
+    return { files, basePath };
+  } catch (error) {
+    console.warn(`[banner-carousel] Falling back to static manifest for ${endpoint}:`, error);
+    return { files: fallbackFiles, basePath: fallbackBasePath };
+  }
+}
+
+function buildImageList(primary, fallback, required) {
+  const seen = new Set();
+  const result = [];
+  const combined = [...primary, ...fallback];
+  for (const file of combined) {
+    if (!file || seen.has(file)) continue;
+    seen.add(file);
+    result.push(file);
+    if (result.length >= required) break;
+  }
+  return result;
+}
+
+function resolveAssetPath(basePath, fileName) {
+  const normalizedBase = basePath.replace(/\/$/, '');
+  return `${normalizedBase}/${fileName}`;
+}
+
+function applyBannerImages(slider, images, basePath) {
+  const items = Array.from(slider.querySelectorAll('.item'));
+  items.forEach((item, index) => {
+    const card = item.querySelector('.service-card');
+    if (!card) return;
+    const fileName = images[index % images.length];
+    const imageUrl = resolveAssetPath(basePath, fileName);
+    card.style.setProperty('--panel-image', `url("${imageUrl}")`);
+    card.dataset.imageSrc = imageUrl;
+    card.dataset.imageFile = fileName;
+  });
+  slider.style.setProperty('--quantity', items.length);
+}
+
+function createExpansionOverlay() {
+  const overlay = document.createElement('div');
+  overlay.className = 'banner-expansion';
+  overlay.innerHTML = `
+    <div class="banner-expansion__backdrop" data-expansion-close></div>
+    <div class="banner-expansion__card">
+      <button type="button" class="banner-expansion__close" aria-label="Close service spotlight" data-expansion-close>&times;</button>
+      <div class="banner-expansion__content">
+        <h3 class="banner-expansion__title"></h3>
+        <p class="banner-expansion__copy"></p>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+
+  const titleEl = overlay.querySelector('.banner-expansion__title');
+  const copyEl = overlay.querySelector('.banner-expansion__copy');
+  const cardEl = overlay.querySelector('.banner-expansion__card');
+
+  const close = () => {
+    if (!overlay.classList.contains('is-visible')) return;
+    overlay.classList.remove('is-visible');
+    document.body.classList.remove('banner-expansion--open');
+  };
+
+  overlay.addEventListener('click', (event) => {
+    if (event.target.matches('[data-expansion-close]')) {
+      close();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') close();
+  });
+
+  const open = (title, copy, imageUrl) => {
+    titleEl.textContent = title;
+    copyEl.textContent = copy;
+    if (imageUrl) {
+      cardEl.style.setProperty('--panel-image', `url("${imageUrl}")`);
+    } else {
+      cardEl.style.removeProperty('--panel-image');
+    }
+    overlay.classList.add('is-visible');
+    document.body.classList.add('banner-expansion--open');
+  };
+
+  return { open, close, element: overlay };
+}
+
+function initBannerCarousel(slider) {
+  const items = Array.from(slider.querySelectorAll('.item'));
+  if (!items.length) return;
+
+  const overlay = createExpansionOverlay();
+  const angleStep = 360 / items.length;
+  const state = {
+    rotation: 0,
+    velocity: 0,
+    pointerActive: false,
+    dragMoved: false,
+    preventClick: false,
+    pointerStartX: 0,
+    lastPointerX: 0,
+    inertiaFrame: null,
+    animationFrame: null
+  };
+
+  const setRotation = (value) => {
+    state.rotation = value;
+    slider.style.setProperty('--rotation', `${value}deg`);
+    updateActive();
+  };
+
+  const cancelInertia = () => {
+    if (state.inertiaFrame) {
+      cancelAnimationFrame(state.inertiaFrame);
+      state.inertiaFrame = null;
+    }
+    state.velocity = 0;
+  };
+
+  const cancelAnimation = () => {
+    if (state.animationFrame) {
+      cancelAnimationFrame(state.animationFrame);
+      state.animationFrame = null;
+    }
+  };
+
+  const normalizeIndex = (value) => {
+    const size = items.length;
+    return ((value % size) + size) % size;
+  };
+
+  const getIndexFromRotation = (rotation) => {
+    const raw = Math.round((-rotation) / angleStep);
+    return normalizeIndex(raw);
+  };
+
+  const updateActive = () => {
+    const activeIndex = getIndexFromRotation(state.rotation);
+    items.forEach((item, index) => {
+      item.classList.toggle('is-active', index === activeIndex);
+    });
+  };
+
+  const shortestAngleDifference = (from, to) => {
+    let diff = ((to - from + 540) % 360) - 180;
+    if (diff < -180) diff += 360;
+    return diff;
+  };
+
+  const focusOnIndex = (targetIndex, duration = 520) => {
+    cancelInertia();
+    cancelAnimation();
+    const targetRotation = -targetIndex * angleStep;
+    const startRotation = state.rotation;
+    const delta = shortestAngleDifference(startRotation, targetRotation);
+    if (Math.abs(delta) < 0.01) {
+      setRotation(targetRotation);
+      return Promise.resolve(targetIndex);
+    }
+    return new Promise((resolve) => {
+      const startTime = performance.now();
+      const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+      const step = (now) => {
+        const elapsed = now - startTime;
+        const progress = Math.min(1, elapsed / duration);
+        const eased = easeOutCubic(progress);
+        setRotation(startRotation + delta * eased);
+        if (progress < 1) {
+          state.animationFrame = requestAnimationFrame(step);
+        } else {
+          cancelAnimation();
+          setRotation(targetRotation);
+          resolve(targetIndex);
+        }
+      };
+      state.animationFrame = requestAnimationFrame(step);
+    });
+  };
+
+  const snapToNearest = () => {
+    const index = getIndexFromRotation(state.rotation);
+    focusOnIndex(index, 360);
+  };
+
+  const startInertia = () => {
+    cancelAnimation();
+    if (Math.abs(state.velocity) < 0.05) {
+      snapToNearest();
+      return;
+    }
+    const friction = 0.94;
+    const step = () => {
+      state.velocity *= friction;
+      if (Math.abs(state.velocity) < 0.05) {
+        cancelInertia();
+        snapToNearest();
+        return;
+      }
+      setRotation(state.rotation + state.velocity);
+      state.inertiaFrame = requestAnimationFrame(step);
+    };
+    state.inertiaFrame = requestAnimationFrame(step);
+  };
+
+  const pointerDown = (event) => {
+    if (document.body.classList.contains('banner-expansion--open')) return;
+    state.pointerActive = true;
+    state.dragMoved = false;
+    state.pointerStartX = event.clientX;
+    state.lastPointerX = event.clientX;
+    slider.classList.add('is-grabbing');
+    cancelAnimation();
+    cancelInertia();
+    slider.setPointerCapture(event.pointerId);
+  };
+
+  const pointerMove = (event) => {
+    if (!state.pointerActive) return;
+    event.preventDefault();
+    const currentX = event.clientX;
+    const deltaX = currentX - state.lastPointerX;
+    if (!state.dragMoved && Math.abs(currentX - state.pointerStartX) > 3) {
+      state.dragMoved = true;
+    }
+    const deltaRotation = deltaX * 0.4;
+    state.velocity = deltaRotation;
+    setRotation(state.rotation + deltaRotation);
+    state.lastPointerX = currentX;
+  };
+
+  const pointerUp = (event) => {
+    if (!state.pointerActive) return;
+    slider.releasePointerCapture(event.pointerId);
+    state.pointerActive = false;
+    slider.classList.remove('is-grabbing');
+    if (state.dragMoved) {
+      state.preventClick = true;
+      setTimeout(() => {
+        state.preventClick = false;
+      }, 0);
+      startInertia();
+    } else {
+      snapToNearest();
+    }
+    state.dragMoved = false;
+    state.pointerStartX = 0;
+    state.lastPointerX = 0;
+  };
+
+  slider.addEventListener('pointerdown', pointerDown);
+  slider.addEventListener('pointermove', pointerMove);
+  slider.addEventListener('pointerup', pointerUp);
+  slider.addEventListener('pointercancel', pointerUp);
+  slider.addEventListener('pointerleave', () => {
+    if (!state.pointerActive) return;
+    state.pointerActive = false;
+    slider.classList.remove('is-grabbing');
+    startInertia();
+    state.dragMoved = false;
+  });
+
+  items.forEach((item, index) => {
+    item.dataset.index = String(index);
+    item.addEventListener('click', (event) => {
+      if (state.preventClick) {
+        event.preventDefault();
+        return;
+      }
+      focusOnIndex(index, 520).then(() => {
+        const card = item.querySelector('.service-card');
+        if (!card) return;
+        const nameEl = card.querySelector('.service-name');
+        const serviceName = nameEl ? nameEl.textContent.trim() : 'Service Spotlight';
+        const description = CARD_DETAILS[serviceName] || 'Explore how this capability strengthens your payment experience and keeps customers moving forward.';
+        overlay.open(serviceName, description, card.dataset.imageSrc);
+      });
+    });
+  });
+
+  setRotation(0);
+}
+
+async function initIntegrationsCarousel() {
+  const track = document.getElementById('integrations-track');
+  if (!track) return;
+  const { files, basePath } = await fetchAssetList(INTEGRATIONS_ENDPOINT, FALLBACK_INTEGRATION_IMAGES, 'assets/integrations');
+  const uniqueLogos = buildImageList(files, FALLBACK_INTEGRATION_IMAGES, files.length || FALLBACK_INTEGRATION_IMAGES.length);
+  if (!uniqueLogos.length) return;
+  track.innerHTML = '';
+  const seamlessList = uniqueLogos.concat(uniqueLogos);
+  seamlessList.forEach((fileName) => {
+    const logoName = fileName.replace(/\.[^.]+$/, '').replace(/[_-]+/g, ' ');
+    const item = document.createElement('div');
+    item.className = 'integration-item flex-shrink-0';
+    const img = document.createElement('img');
+    img.src = resolveAssetPath(basePath, fileName);
+    img.alt = `${logoName} Logo`;
+    img.loading = 'lazy';
+    img.className = 'integration-logo h-10 sm:h-12 object-contain';
+    if (/shopify|gohighlevel/i.test(fileName)) {
+      img.classList.add('integration-logo--xl');
+    }
+    item.appendChild(img);
+    track.appendChild(item);
+  });
+}
+
+async function init() {
+  await ready();
+  const slider = document.querySelector('.banner .slider');
+  if (slider) {
+    const itemCount = slider.querySelectorAll('.item').length || FALLBACK_BANNER_IMAGES.length;
+    const { files, basePath } = await fetchAssetList(BANNER_ENDPOINT, FALLBACK_BANNER_IMAGES, 'assets/img');
+    const images = buildImageList(files, FALLBACK_BANNER_IMAGES, itemCount);
+    applyBannerImages(slider, images, basePath);
+    initBannerCarousel(slider);
+  }
+  initIntegrationsCarousel();
+}
+
+init();

--- a/assets/integrations/memberpress.svg
+++ b/assets/integrations/memberpress.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 120" role="img" aria-labelledby="title desc">
+  <title id="title">MemberPress Logo</title>
+  <desc id="desc">Stylised MP monogram used as a placeholder logo for MemberPress integrations carousel.</desc>
+  <defs>
+    <linearGradient id="mpGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a94ff" />
+      <stop offset="100%" stop-color="#3bd9c6" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="120" rx="18" fill="#0f172a" />
+  <path fill="url(#mpGradient)" d="M52 84V36h19.6l17.2 23.7L106 36h19.6v48H108V61l-19.2 26.6H84L64.8 61v23H52zm109.4 0V36h22.3c15.5 0 25.9 9.6 25.9 24s-10.4 24-25.9 24h-22.3zm21.8-13.3c6.3 0 10.4-3.8 10.4-10.7 0-6.9-4.1-10.7-10.4-10.7h-6.6v21.4h6.6z" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -370,9 +370,12 @@
   padding: 0.5rem 0.75rem;
 }
 #integrations .integration-logo {
+  --logo-scale: 1;
+  --logo-hover-scale: calc(var(--logo-scale) * 1.1);
   display: block;
   opacity: 0.95;
   transition: transform 0.3s ease, filter 0.3s ease, opacity 0.3s ease;
+  transform: scale(var(--logo-scale));
 }
 #integrations .integration-hero-logo {
   width: clamp(12rem, 28vw, 20rem);
@@ -381,8 +384,16 @@
   filter: drop-shadow(0 10px 25px rgba(16, 24, 40, 0.3));
 }
 #integrations .integration-item:hover .integration-logo {
-  transform: scale(1.1);
+  transform: scale(var(--logo-hover-scale));
   opacity: 1;
+}
+.integration-logo--xl {
+  --logo-scale: 1.95;
+}
+@media (max-width: 768px) {
+  .integration-logo--xl {
+    --logo-scale: 1.6;
+  }
 }
 .dark #integrations .integration-logo {
   filter: brightness(1.15) contrast(1.05);
@@ -414,41 +425,52 @@
             backdrop-filter: blur(14px);
         }
         .banner {
+            --card-width: clamp(9.75rem, 18vw, 13rem);
+            --card-height: calc(var(--card-width) * 16 / 9);
+            --tilt: -16deg;
+            --translateZ: calc(var(--card-width) * 4.6);
             width: 100%;
-            min-height: clamp(28rem, 70vh, 40rem);
+            min-height: clamp(30rem, 70vh, 42rem);
             text-align: center;
-            overflow: hidden;
             position: relative;
-            perspective: 1500px;
+            perspective: 1600px;
+            touch-action: pan-y;
         }
         .banner .slider {
+            --rotation: 0deg;
             position: absolute;
-            width: 160px;
-            height: 200px;
-            top: 10%;
-            left: calc(50% - 80px);
+            top: 50%;
+            left: 50%;
+            width: var(--card-width);
+            height: var(--card-height);
             transform-style: preserve-3d;
-            transform: perspective(1500px) rotateX(-18deg);
-            animation: autoRun 40s linear infinite;
+            transform: translate(-50%, -50%) rotateX(var(--tilt)) rotateY(var(--rotation));
+            cursor: grab;
+            user-select: none;
+            transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
             z-index: 2;
         }
-        .banner:hover .slider {
-            animation-play-state: paused;
-        }
-        @keyframes autoRun {
-            from {
-                transform: perspective(1500px) rotateX(-18deg) rotateY(0deg);
-            }
-            to {
-                transform: perspective(1500px) rotateX(-18deg) rotateY(360deg);
-            }
+        .banner .slider.is-grabbing {
+            cursor: grabbing;
+            transition: none;
         }
         .banner .slider .item {
             position: absolute;
             inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transform-style: preserve-3d;
             transform:
-                rotateY(calc((var(--position) - 1) * (360 / var(--quantity)) * 1deg))
-                translateZ(380px);
+                rotateY(calc((var(--position) - 1) * (360deg / var(--quantity))))
+                translateZ(var(--translateZ));
+        }
+        .banner .item.is-active .service-card {
+            box-shadow: 0 24px 48px rgba(15, 23, 42, 0.4);
+            background: rgba(255, 255, 255, 0.94);
+        }
+        .banner .item.is-active .service-card::after {
+            opacity: 0.68;
         }
         .banner .model {
             position: absolute;
@@ -464,37 +486,60 @@
             filter: drop-shadow(0 18px 35px rgba(0, 0, 0, 0.45));
         }
         .service-card {
-            width: 100%;
-            height: 100%;
-            border-radius: 1rem;
-            background: rgba(255, 255, 255, 0.85);
-            box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
-            overflow: hidden;
+            position: relative;
+            width: var(--card-width);
+            height: var(--card-height);
+            border-radius: 1.35rem;
+            background: rgba(255, 255, 255, 0.88);
+            box-shadow: 0 14px 32px rgba(15, 23, 42, 0.28);
+            overflow: visible;
             color: #1a1a1a;
             font-family: 'Ubuntu', sans-serif;
             font-weight: 600;
             text-align: center;
             transition: transform 0.35s ease, box-shadow 0.35s ease, background 0.35s ease;
-            position: relative;
-            transform: translateY(-10%);
-            --service-image-brightness: 70%;
-            -webkit-box-reflect: below 0 linear-gradient(transparent 0%, rgba(15, 23, 42, 0.45) 55%, rgba(15, 23, 42, 0.75));
+            transform: translateY(-12%);
+            display: flex;
+            --service-image-brightness: 72%;
+            --panel-image: none;
+        }
+        .service-card::after {
+            content: '';
+            position: absolute;
+            top: calc(100% + 14px);
+            left: 0;
+            width: 100%;
+            height: calc(var(--card-height) * 0.42);
+            background-image:
+                linear-gradient(180deg, rgba(15, 23, 42, 0.38) 0%, rgba(15, 23, 42, 0.05) 70%),
+                var(--panel-image);
+            background-size: cover;
+            background-position: center;
+            transform: scaleY(-1);
+            transform-origin: top;
+            opacity: 0.52;
+            filter: blur(0.25px) saturate(0.95);
+            pointer-events: none;
+            -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent);
+                    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent);
         }
         .service-card:hover {
-            transform: translateY(calc(-10% - 8px)) scale(1.02);
-            box-shadow: 0 12px 28px rgba(15, 23, 42, 0.3);
-            background: rgba(255, 255, 255, 0.92);
-            --service-image-brightness: 85%;
+            transform: translateY(calc(-12% - 8px)) scale(1.02);
+            box-shadow: 0 20px 38px rgba(15, 23, 42, 0.34);
+            background: rgba(255, 255, 255, 0.95);
+            --service-image-brightness: 82%;
         }
         .service-image {
             position: relative;
             display: flex;
-            min-height: 220px;
+            flex: 1 1 auto;
+            background-image: linear-gradient(145deg, rgba(0, 206, 219, 0.18), rgba(124, 58, 237, 0.18)), var(--panel-image);
             background-size: cover;
             background-position: center;
             filter: brightness(var(--service-image-brightness)) saturate(1.05);
             transition: transform 0.6s ease, filter 0.6s ease;
             overflow: hidden;
+            border-radius: inherit;
         }
         .service-image::before {
             content: '';
@@ -502,13 +547,13 @@
             inset: 0;
             background-image: linear-gradient(145deg, rgba(0, 206, 219, 0.35), rgba(124, 58, 237, 0.35));
             mix-blend-mode: screen;
-            opacity: 0.85;
+            opacity: 0.75;
         }
         .service-image::after {
             content: '';
             position: absolute;
             inset: 0;
-            background: linear-gradient(180deg, rgba(15, 23, 42, 0.05) 0%, rgba(15, 23, 42, 0.65) 100%);
+            background: linear-gradient(180deg, rgba(15, 23, 42, 0.05) 0%, rgba(15, 23, 42, 0.68) 100%);
         }
         .service-card:hover .service-image {
             transform: scale(1.02);
@@ -574,16 +619,110 @@
                 font-size: 1rem;
             }
         }
-        .banner .item:nth-child(1) .service-image { background-image: linear-gradient(rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.1)), url('assets/img/card1.png'); }
-        .banner .item:nth-child(2) .service-image { background-image: linear-gradient(rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.1)), url('assets/img/card2.png'); }
-        .banner .item:nth-child(3) .service-image { background-image: linear-gradient(rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.1)), url('assets/img/card3.png'); }
-        .banner .item:nth-child(4) .service-image { background-image: linear-gradient(rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.1)), url('assets/img/card4.png'); }
-        .banner .item:nth-child(5) .service-image { background-image: linear-gradient(rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.1)), url('assets/img/card5.png'); }
-        .banner .item:nth-child(6) .service-image { background-image: linear-gradient(rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.1)), url('assets/img/card6.png'); }
-        .banner .item:nth-child(7) .service-image { background-image: linear-gradient(rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.1)), url('assets/img/card7.png'); }
-        .banner .item:nth-child(8) .service-image { background-image: linear-gradient(rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.1)), url('assets/img/card8.png'); }
-        .banner .item:nth-child(9) .service-image { background-image: linear-gradient(rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.1)), url('assets/img/card9.png'); }
-        .banner .item:nth-child(10) .service-image { background-image: linear-gradient(rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.1)), url('assets/img/card10.png'); }
+        @media (max-width: 1023px) {
+            .banner {
+                --card-width: clamp(8.5rem, 28vw, 11rem);
+                --translateZ: calc(var(--card-width) * 4);
+                --tilt: -14deg;
+            }
+        }
+        @media (max-width: 767px) {
+            .banner {
+                min-height: 26rem;
+                --card-width: clamp(7.25rem, 42vw, 9.5rem);
+                --translateZ: calc(var(--card-width) * 3.4);
+            }
+            .service-overlay {
+                padding: 2rem 1.25rem;
+            }
+        }
+        .banner-expansion {
+            position: fixed;
+            inset: 0;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(1.5rem, 6vw, 3rem);
+            z-index: 70;
+        }
+        .banner-expansion.is-visible {
+            display: flex;
+        }
+        .banner-expansion__backdrop {
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(180deg, rgba(13, 18, 30, 0.85), rgba(13, 18, 30, 0.92));
+            backdrop-filter: blur(12px);
+        }
+        .banner-expansion__card {
+            position: relative;
+            width: min(90vw, 520px);
+            aspect-ratio: 9 / 16;
+            border-radius: 1.6rem;
+            overflow: hidden;
+            background-image: linear-gradient(160deg, rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.65)), var(--panel-image, none);
+            background-size: cover;
+            background-position: center;
+            box-shadow: 0 40px 80px rgba(15, 23, 42, 0.55);
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-end;
+            padding: clamp(1.5rem, 3vh, 2.5rem);
+            color: #f8fafc;
+        }
+        .banner-expansion__card::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(180deg, rgba(15, 23, 42, 0.05) 0%, rgba(15, 23, 42, 0.78) 85%);
+            z-index: 0;
+        }
+        .banner-expansion__content {
+            position: relative;
+            z-index: 1;
+            display: grid;
+            gap: 0.75rem;
+        }
+        .banner-expansion__title {
+            font-size: clamp(1.75rem, 3vw, 2.25rem);
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+        .banner-expansion__copy {
+            font-size: clamp(1rem, 2.1vw, 1.125rem);
+            line-height: 1.6;
+            color: rgba(241, 245, 249, 0.95);
+        }
+        .banner-expansion__close {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 2.5rem;
+            height: 2.5rem;
+            border-radius: 999px;
+            background: rgba(15, 23, 42, 0.65);
+            color: #f8fafc;
+            border: 1px solid rgba(248, 250, 252, 0.2);
+            backdrop-filter: blur(4px);
+            transition: transform 0.2s ease, background 0.2s ease;
+            z-index: 2;
+        }
+        .banner-expansion__close:hover {
+            transform: scale(1.05);
+            background: rgba(220, 20, 60, 0.85);
+        }
+        @media (max-width: 640px) {
+            .banner-expansion__card {
+                width: min(92vw, 380px);
+            }
+        }
+        body.banner-expansion--open {
+            overflow: hidden;
+        }
         .loader {
             width: 20px;
             height: 20px;
@@ -847,9 +986,9 @@
 <section id="integrations" class="py-16 md:py-24">
     <div class="max-w-7xl mx-auto px-4 text-center space-y-12">
         <div class="grid grid-cols-[1fr,auto,1fr] items-center gap-4 md:gap-8 max-w-4xl mx-auto">
-            <img src="public/assets/images/shopifydark.png" alt="Shopify Logo" class="integration-logo integration-hero-logo object-contain justify-self-end">
+            <img src="public/assets/images/shopifydark.png" alt="Shopify Logo" class="integration-logo integration-hero-logo integration-logo--xl object-contain justify-self-end">
             <h2 class="text-2xl sm:text-3xl md:text-4xl font-bold font-ubuntu uppercase tracking-wide">Integrate With Your Favorite Tools</h2>
-            <img src="public/assets/images/gohighleveldark.png" alt="GoHighLevel Logo" class="integration-logo integration-hero-logo object-contain justify-self-start">
+            <img src="public/assets/images/gohighleveldark.png" alt="GoHighLevel Logo" class="integration-logo integration-hero-logo integration-logo--xl object-contain justify-self-start">
         </div>
 
         <p class="text-lg text-slate-300 max-w-2xl mx-auto">Connect with your favorite tools and services</p>
@@ -1255,25 +1394,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  // --- NEW INTEGRATIONS SCRIPT ---
-  const integrationLogos = [
-      'bigcommerce.webp', 'clover.webp', 'freshbooks.webp', 'hubspot.webp',
-      'keap.webp', 'lightspeed.webp', 'magento.webp', 'mastercard.webp',
-      'memberpress.webp', 'ncr.webp', 'quickbooks.webp', 'salesforce.webp',
-      'squarespace.webp', 'vend.webp', 'visa.webp', 'wix.webp',
-      'woocommerce.webp', 'zoho_crm.webp'
-  ];
-  const integrationsTrack = document.getElementById('integrations-track');
-  if (integrationsTrack) {
-    const allLogos = [...integrationLogos, ...integrationLogos]; // Duplicate for seamless loop
-    allLogos.forEach(logoFile => {
-        const logoName = logoFile.split('.')[0].replace('_', ' ').replace('-', ' ');
-        const item = document.createElement('div');
-        item.className = 'integration-item flex-shrink-0';
-        item.innerHTML = `<img src="assets/integrations/${logoFile}" alt="${logoName} Logo" class="integration-logo h-10 sm:h-12 object-contain">`;
-        integrationsTrack.appendChild(item);
-    });
-  }
   const headingTexts = { "integrations-old": "Integrate with Your Favorite Tools" }; // Old logic, can be removed or updated
   const headingObserver = new IntersectionObserver((entries, observer) => {
     entries.forEach(entry => {
@@ -1542,6 +1662,7 @@ document.addEventListener('DOMContentLoaded', () => {
     <!-- ================= GLOBAL LAYOUT SCRIPTS START ================= -->
     <!-- External signup panel logic plus helpers for navigation, logos, and UI polish -->
     <script src="/assets/signup-panel.js" defer></script>
+    <script type="module" src="/assets/banner-carousel.js"></script>
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/netlify/functions/list-assets.js
+++ b/netlify/functions/list-assets.js
@@ -1,0 +1,50 @@
+const path = require('path');
+const { promises: fs } = require('fs');
+
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg', '.avif']);
+
+const DIRECTORY_MAP = {
+  banner: {
+    folder: path.join(process.cwd(), 'assets', 'img'),
+    publicPath: 'assets/img'
+  },
+  integrations: {
+    folder: path.join(process.cwd(), 'assets', 'integrations'),
+    publicPath: 'assets/integrations'
+  }
+};
+
+exports.handler = async (event) => {
+  const type = (event.queryStringParameters && event.queryStringParameters.type) || '';
+  const config = DIRECTORY_MAP[type];
+
+  if (!config) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Invalid asset type request.' })
+    };
+  }
+
+  try {
+    const entries = await fs.readdir(config.folder, { withFileTypes: true });
+    const files = entries
+      .filter((entry) => entry.isFile() && IMAGE_EXTENSIONS.has(path.extname(entry.name).toLowerCase()))
+      .map((entry) => entry.name)
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }));
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=3600'
+      },
+      body: JSON.stringify({ files, basePath: config.publicPath })
+    };
+  } catch (error) {
+    console.error('Failed to enumerate assets', error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Unable to list assets at this time.' })
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- add a standalone banner carousel module that fetches asset manifests and drives the interactive rotation/overlay experience
- restyle the payments banner and integrations section to use dynamic assets with responsive scaling and hero logo adjustments
- expose a Netlify function for listing available banner/integration images and add a MemberPress placeholder asset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de8a060094833086d8750ffc795ade