### PR TITLE
Adjust service card brightness and text colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -500,7 +500,7 @@
             transition: transform 0.35s ease, box-shadow 0.35s ease, background 0.35s ease;
             transform: translateY(-12%);
             display: flex;
-            --service-image-brightness: 72%;
+            --service-image-brightness: 67%;
             --panel-image: none;
         }
         .service-card::after {
@@ -527,7 +527,7 @@
             transform: translateY(calc(-12% - 8px)) scale(1.02);
             box-shadow: 0 20px 38px rgba(15, 23, 42, 0.34);
             background: rgba(255, 255, 255, 0.95);
-            --service-image-brightness: 82%;
+            --service-image-brightness: 77%;
         }
         .service-image {
             position: relative;
@@ -574,8 +574,8 @@
             width: 100%;
             background: none;
             backdrop-filter: none;
-            color: #1a1a1a;
-            text-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+            color: #ffffff;
+            text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
         }
         .service-icon-wrap {
             display: inline-flex;
@@ -591,7 +591,7 @@
             width: 2.2rem;
             height: 2.2rem;
             stroke-width: 1.5;
-            color: #2c3e50;
+            color: #ffffff;
         }
         .service-name {
             font-size: 1.2rem;


### PR DESCRIPTION
## Summary
- decrease the base and hover brightness applied to service card imagery to make panels appear slightly darker
- update service card overlay styling so text and icons render in white with stronger contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de95a9d92883309abd9081a30afdc2