### PR TITLE
Improve responsive scaling for hero and carousel

### DIFF
--- a/assets/support.js
+++ b/assets/support.js
@@ -120,7 +120,7 @@
     wrapper.innerHTML = `
       <div id="support-modal" class="fixed inset-0 z-[70] hidden flex items-center justify-center">
         <div class="absolute inset-0 bg-black/60" data-close></div>
-        <div class="relative z-10 w-[min(560px,92vw)] max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-2xl border border-slate-200" data-modal-card>
+        <div class="relative z-10 w-full max-w-[clamp(20rem,90vw,35rem)] max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-2xl border border-slate-200" data-modal-card>
           <div class="flex items-center justify-between">
             <h3 class="text-xl font-extrabold font-ubuntu text-slate-900">Contact Support</h3>
             <button class="p-2 text-slate-500 hover:text-slate-700" data-close aria-label="Close">

--- a/gohighlevel.html
+++ b/gohighlevel.html
@@ -296,7 +296,7 @@
 <!-- Shared modal -->
 <div class="fixed inset-0 z-[70] hidden" id="book-modal">
 <div class="absolute inset-0 bg-black/60" data-close=""></div>
-<div class="mx-auto mt-[10vh] w-[min(560px,92vw)] rounded-2xl bg-white dark:bg-slate-900 p-6 border border-slate-200 dark:border-slate-800 shadow-2xl">
+<div class="mx-auto mt-[10vh] w-full max-w-[clamp(20rem,90vw,35rem)] rounded-2xl bg-white dark:bg-slate-900 p-6 border border-slate-200 dark:border-slate-800 shadow-2xl">
 <div class="flex items-center justify-between">
 <h3 class="text-xl font-extrabold">Book a 20-minute consultation</h3>
 <button aria-label="Close" class="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" data-close="">

--- a/index.html
+++ b/index.html
@@ -51,9 +51,6 @@
 
     <!-- Custom Styles -->
     <style>
-        html, body {
-            overflow-x: hidden;
-        }
         html {
             scroll-behavior: smooth;
         }
@@ -151,8 +148,25 @@
         }
 
         .hero-overlay {
-            max-width: min(100%, 80rem);
+            max-width: clamp(90%, 80rem, 100%);
             width: 100%;
+        }
+
+        .hero-heading {
+            font-size: clamp(1.75rem, 4vw + 0.5rem, 3.25rem);
+            line-height: 1.15;
+        }
+
+        .hero-subheading {
+            font-size: clamp(1.25rem, 3vw + 0.25rem, 2.5rem);
+        }
+
+        .section-heading {
+            font-size: clamp(1.5rem, 3vw + 0.5rem, 2.75rem);
+        }
+
+        .section-subheading {
+            font-size: clamp(1.125rem, 2.5vw, 2.25rem);
         }
 
         .application-section {
@@ -405,8 +419,6 @@
 .dark #integrations .integration-logo {
   filter: brightness(1.15) contrast(1.05);
 }
-
-
         /* === PAYMENT SERVICES EXPERIENCE === */
         #payments {
             position: relative;
@@ -432,12 +444,12 @@
             backdrop-filter: blur(14px);
         }
         .banner {
-            --card-width: clamp(9.75rem, 18vw, 13rem);
+            --card-width: clamp(7rem, 40vw, 13rem);
             --card-height: calc(var(--card-width) * 16 / 9);
             --tilt: -16deg;
-            --translateZ: calc(var(--card-width) * 4.6);
+            --translateZ: calc(var(--card-width) * 3);
             width: 100%;
-            min-height: clamp(30rem, 70vh, 42rem);
+            min-height: clamp(24rem, 65vh, 38rem);
             text-align: center;
             position: relative;
             perspective: 1600px;
@@ -483,7 +495,7 @@
             position: absolute;
             inset: auto 0 0;
             margin: 0 auto;
-            width: min(520px, 90vw);
+            width: clamp(14rem, 70vw, 32.5rem);
             height: clamp(18rem, 45vh, 24rem);
             background-image: url('assets/3dbanner/images/model.png');
             background-repeat: no-repeat;
@@ -628,16 +640,16 @@
         }
         @media (max-width: 1023px) {
             .banner {
-                --card-width: clamp(8.5rem, 28vw, 11rem);
-                --translateZ: calc(var(--card-width) * 4);
+                --card-width: clamp(6.5rem, 46vw, 11rem);
+                --translateZ: calc(var(--card-width) * 2.75);
                 --tilt: -14deg;
             }
         }
         @media (max-width: 767px) {
             .banner {
-                min-height: 26rem;
-                --card-width: clamp(7.25rem, 42vw, 9.5rem);
-                --translateZ: calc(var(--card-width) * 3.4);
+                min-height: clamp(20rem, 70vh, 28rem);
+                --card-width: clamp(6rem, 50vw, 9rem);
+                --translateZ: calc(var(--card-width) * 2.5);
             }
             .service-overlay {
                 padding: 2rem 1.25rem;
@@ -663,7 +675,7 @@
         }
         .banner-expansion__card {
             position: relative;
-            width: min(90vw, 520px);
+            width: clamp(18rem, 90vw, 32.5rem);
             aspect-ratio: 9 / 16;
             border-radius: 1.6rem;
             overflow: hidden;
@@ -724,7 +736,7 @@
         }
         @media (max-width: 640px) {
             .banner-expansion__card {
-                width: min(92vw, 380px);
+                width: clamp(16rem, 92vw, 23.75rem);
             }
         }
         body.banner-expansion--open {
@@ -744,33 +756,6 @@
             0% { transform: rotate(0deg); }
             100% { transform: rotate(360deg); }
         }
-        @media (max-width: 1023px) {
-            .banner .slider {
-                width: 140px;
-                height: 180px;
-                left: calc(50% - 70px);
-            }
-            .banner .slider .item {
-                transform:
-                    rotateY(calc((var(--position) - 1) * (360 / var(--quantity)) * 1deg))
-                    translateZ(300px);
-            }
-        }
-        @media (max-width: 767px) {
-            .banner {
-                min-height: 26rem;
-            }
-            .banner .slider {
-                width: 110px;
-                height: 150px;
-                left: calc(50% - 55px);
-            }
-            .banner .slider .item {
-                transform:
-                    rotateY(calc((var(--position) - 1) * (360 / var(--quantity)) * 1deg))
-                    translateZ(210px);
-            }
-        }
         /* === END PAYMENT SERVICES EXPERIENCE === */
 </style>
 <!-- ================= INLINE EXPERIENCE STYLES END ================= -->
@@ -783,9 +768,9 @@
     <div class="max-w-7xl mx-auto px-4 pt-12 sm:pt-16 md:pt-24 pb-20 md:pb-28">
       <div class="flex flex-col-reverse hero-layout md:grid md:grid-cols-2 md:gap-10 items-center">
         <div class="space-y-6 text-left hero-text">
-          <h1 class="text-3xl sm:text-4xl tracking-tight leading-tight text-white">
+          <h1 class="hero-heading tracking-tight text-white">
             <span class="uppercase font-ubuntu">PAYMENTS ANYWHERE - GROWTH EVERYWHERE</span>
-            <span id="animated-headline-sub" class="grad-text-static text-2xl sm:text-3xl font-ubuntu inline sm:inline sm:ml-2">Engineered for speed, secured for trust, and designed to scale.</span>
+            <span id="animated-headline-sub" class="grad-text-static hero-subheading font-ubuntu inline sm:ml-2">Engineered for speed, secured for trust, and designed to scale.</span>
           </h1>
           <p class="text-lg text-gray-200 dark:text-slate-300 font-inter text-center md:text-justify" style="font-weight:100">Effortlessly create your business profile and start accepting payments in minutes—cards, ACH, and secure pay links across online, in-store, and mobile. Lower your costs, onboard quickly, track performance in real time, and protect your business with advanced fraud and chargeback tools.</p>
         </div>
@@ -815,15 +800,15 @@
 <!-- 3D carousel and CTAs highlighting core payment capabilities -->
 <div class="relative pt-32 w-full">
   <div class="absolute top-0 left-0 w-full h-48 bg-[#1c1c1c]"></div>
-  <div class="hero-overlay absolute top-32 left-1/2 -translate-x-1/2 -translate-y-1/2 z-20 w-full max-w-5xl px-4">
+  <div class="hero-overlay absolute top-32 left-1/2 -translate-x-1/2 -translate-y-1/2 z-20 w-full px-4">
     <div class="payments-heading-card text-slate-200 px-8 py-4 rounded-xl border-2 border-brand-crimson shadow-lg text-center">
-      <h2 class="text-3xl font-ubuntu font-bold">Payment Services Tailored for You</h2>
+      <h2 class="section-heading font-ubuntu font-bold">Payment Services Tailored for You</h2>
     </div>
   </div>
 
   <section id="payments" class="pt-28 pb-12">
     <div class="max-w-5xl mx-auto px-4 text-center">
-      <p class="text-2xl sm:text-3xl font-ubuntu mb-4 text-slate-300">Your complete business toolkit for accepting and managing payments.</p>
+      <p class="section-subheading font-ubuntu mb-4 text-slate-300">Your complete business toolkit for accepting and managing payments.</p>
     </div>
 
     <div class="banner">
@@ -1069,7 +1054,7 @@
       </div>
     </div>
   </section>
-  <div class="hero-overlay absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 w-full max-w-5xl px-4">
+  <div class="hero-overlay absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 w-full px-4">
     <div class="bg-brand-teal px-8 py-4 rounded-xl shadow-lg text-center">
       <h2 class="text-3xl font-ubuntu font-bold" style="color: #524848;">Setup Checklist: What You’ll Need to Begin</h2>
     </div>
@@ -1081,7 +1066,7 @@
 <!-- Contact form modal enabling merchants to reach support team -->
 <div id="support-modal" class="fixed inset-0 z-[70] hidden flex items-center justify-center">
   <div class="absolute inset-0 bg-black/60" data-close></div>
-  <div class="relative z-10 w-[min(560px,92vw)] max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-2xl border border-slate-200" data-modal-card>
+  <div class="relative z-10 w-full max-w-[clamp(20rem,90vw,35rem)] max-h-[90vh] overflow-y-auto rounded-2xl bg-white p-6 shadow-2xl border border-slate-200" data-modal-card>
     <div class="flex items-center justify-between">
       <h3 class="text-xl font-extrabold font-ubuntu text-slate-900">Contact Support</h3>
       <button class="p-2 text-slate-500 hover:text-slate-700" data-close aria-label="Close"><i data-lucide="x" class="h-5 w-5"></i></button>

--- a/integrations/gohighlevel.html
+++ b/integrations/gohighlevel.html
@@ -296,7 +296,7 @@
 <!-- Shared modal -->
 <div class="fixed inset-0 z-[70] hidden" id="book-modal">
 <div class="absolute inset-0 bg-black/60" data-close=""></div>
-<div class="mx-auto mt-[10vh] w-[min(560px,92vw)] rounded-2xl bg-white dark:bg-slate-900 p-6 border border-slate-200 dark:border-slate-800 shadow-2xl">
+<div class="mx-auto mt-[10vh] w-full max-w-[clamp(20rem,90vw,35rem)] rounded-2xl bg-white dark:bg-slate-900 p-6 border border-slate-200 dark:border-slate-800 shadow-2xl">
 <div class="flex items-center justify-between">
 <h3 class="text-xl font-extrabold">Book a 20-minute consultation</h3>
 <button aria-label="Close" class="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" data-close="">

--- a/integrations/shopify.html
+++ b/integrations/shopify.html
@@ -296,7 +296,7 @@
 <!-- Shared modal -->
 <div class="fixed inset-0 z-[70] hidden" id="book-modal">
 <div class="absolute inset-0 bg-black/60" data-close=""></div>
-<div class="mx-auto mt-[10vh] w-[min(560px,92vw)] rounded-2xl bg-white dark:bg-slate-900 p-6 border border-slate-200 dark:border-slate-800 shadow-2xl">
+<div class="mx-auto mt-[10vh] w-full max-w-[clamp(20rem,90vw,35rem)] rounded-2xl bg-white dark:bg-slate-900 p-6 border border-slate-200 dark:border-slate-800 shadow-2xl">
 <div class="flex items-center justify-between">
 <h3 class="text-xl font-extrabold">Book a 20-minute consultation</h3>
 <button aria-label="Close" class="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800" data-close="">


### PR DESCRIPTION
## Summary
- make the hero overlay fluid and introduce clamp-based typography for hero messaging
- remove global horizontal overflow clipping and scale the 3D carousel with viewport-based dimensions
- update modal and banner widths to clamp-based sizing for better small-screen support

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68df3c13d1748330ac4e50dc6db84ae4