### PR TITLE
Add expandable carousel cards for payment services

### DIFF
--- a/index.html
+++ b/index.html
@@ -516,11 +516,46 @@
             font-family: 'Ubuntu', sans-serif;
             font-weight: 600;
             text-align: center;
-            transition: transform 0.35s ease, box-shadow 0.35s ease, background 0.35s ease;
+            transition: transform 0.4s ease, top 0.4s ease, left 0.4s ease,
+                width 0.4s ease, height 0.4s ease, box-shadow 0.4s ease, background 0.35s ease;
             transform: translateY(-12%);
             display: flex;
+            cursor: pointer;
+            background-size: cover;
+            background-position: center;
             --service-image-brightness: 67%;
             --panel-image: none;
+        }
+        .service-card.expanding {
+            transform: scale(1.2);
+            z-index: 50;
+        }
+        .service-card.expanded {
+            position: fixed !important;
+            top: 0;
+            left: 0;
+            width: 100vw !important;
+            height: 100vh !important;
+            z-index: 100;
+            border-radius: 0;
+            transform: none !important;
+        }
+        .service-card.expanded .card-content {
+            position: absolute;
+            bottom: 2rem;
+            left: 2rem;
+            right: 2rem;
+            background: rgba(0, 0, 0, 0.5);
+            padding: 1rem;
+            border-radius: 0.5rem;
+            color: white;
+        }
+        .service-card .details {
+            display: none;
+        }
+        .service-card.expanded .details {
+            display: block;
+            margin-top: 1rem;
         }
         .service-card::after {
             content: '';
@@ -547,6 +582,18 @@
             box-shadow: 0 20px 38px rgba(15, 23, 42, 0.34);
             background: rgba(255, 255, 255, 0.95);
             --service-image-brightness: 77%;
+        }
+        .service-card .card-content {
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-end;
+            gap: 0.75rem;
+            width: 100%;
+            height: 100%;
+            padding: 2rem 1.5rem;
+            border-radius: inherit;
+            background: linear-gradient(180deg, rgba(15, 23, 42, 0.05) 0%, rgba(15, 23, 42, 0.85) 100%);
+            color: #f8fafc;
         }
         .service-image {
             position: relative;
@@ -1189,6 +1236,194 @@
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   if (window.lucide) lucide.createIcons();
+
+  const slider = document.querySelector('.banner .slider');
+  if (slider) {
+    const services = [
+      {
+        icon: "smartphone",
+        title: "Accept Payments Anywhere",
+        description: "Online, in-store, or on the go.",
+        details: "Accept credit cards, mobile wallets, and more with one integration.",
+        link: "/docs/payments",
+        image: "https://placehold.co/800x600/000/fff?text=Payments"
+      },
+      {
+        icon: "shuffle",
+        title: "Smart Routing",
+        description: "Optimize approvals and reduce fees.",
+        details: "Automatically steer each transaction to the least-cost, highest-approval processor.",
+        link: "/docs/routing",
+        image: "https://placehold.co/800x600/111/fff?text=Routing"
+      },
+      {
+        icon: "file-text",
+        title: "Invoicing",
+        description: "Send branded invoices instantly.",
+        details: "Create invoices with pay links, reminders, and partial payment tracking in minutes.",
+        link: "/docs/invoicing",
+        image: "https://placehold.co/800x600/222/fff?text=Invoicing"
+      },
+      {
+        icon: "repeat",
+        title: "Recurring Billing",
+        description: "Automate subscriptions effortlessly.",
+        details: "Manage memberships, payment plans, and retries with automated dunning tools.",
+        link: "/docs/recurring",
+        image: "https://placehold.co/800x600/333/fff?text=Recurring"
+      },
+      {
+        icon: "lock",
+        title: "Secure Tokenization",
+        description: "Keep card data safe and compliant.",
+        details: "Vault sensitive cardholder data with PCI-compliant tokenization across every channel.",
+        link: "/docs/security",
+        image: "https://placehold.co/800x600/444/fff?text=Tokenization"
+      },
+      {
+        icon: "bar-chart-2",
+        title: "Detailed Reporting",
+        description: "Understand performance in real time.",
+        details: "Track settlements, disputes, and trends with dashboards and export-ready reports.",
+        link: "/docs/reporting",
+        image: "https://placehold.co/800x600/555/fff?text=Reporting"
+      },
+      {
+        icon: "cpu",
+        title: "Automation",
+        description: "Trigger workflows automatically.",
+        details: "Connect MerchantHaus to your stack with APIs and webhooks that eliminate manual steps.",
+        link: "/docs/automation",
+        image: "https://placehold.co/800x600/666/fff?text=Automation"
+      },
+      {
+        icon: "landmark",
+        title: "ACH Payments",
+        description: "Offer low-cost bank transfers.",
+        details: "Let customers pay straight from their bank accounts with instant verification and limits.",
+        link: "/docs/ach",
+        image: "https://placehold.co/800x600/777/fff?text=ACH"
+      },
+      {
+        icon: "shield-alert",
+        title: "Fraud Prevention",
+        description: "Block risky transactions in real time.",
+        details: "Layer device intelligence, velocity controls, and ML scoring to stop fraudsters fast.",
+        link: "/docs/fraud",
+        image: "https://placehold.co/800x600/888/fff?text=Fraud"
+      },
+      {
+        icon: "globe-2",
+        title: "Global Payments",
+        description: "Scale across borders confidently.",
+        details: "Support multi-currency pricing and localized methods with dynamic FX management.",
+        link: "/docs/global",
+        image: "https://placehold.co/800x600/999/fff?text=Global"
+      }
+    ];
+
+    slider.innerHTML = '';
+    services.forEach((service, idx) => {
+      const item = document.createElement('div');
+      item.classList.add('item');
+      item.style.setProperty('--position', idx + 1);
+
+      const card = document.createElement('div');
+      card.className = 'service-card';
+      if (service.image) {
+        const imageUrl = `url(${service.image})`;
+        card.style.backgroundImage = imageUrl;
+        card.style.setProperty('--panel-image', imageUrl);
+      }
+
+      card.innerHTML = `
+        <div class="card-content">
+          <i data-lucide="${service.icon}"></i>
+          <h3>${service.title}</h3>
+          <p>${service.description}</p>
+          <div class="details">
+            <p>${service.details || ''}</p>
+            ${service.link ? `<a href="${service.link}" class="underline">Learn more</a>` : ""}
+          </div>
+        </div>
+      `;
+
+      card.addEventListener("click", () => toggleExpand(card));
+      item.appendChild(card);
+      slider.appendChild(item);
+    });
+
+    slider.style.setProperty('--quantity', services.length);
+    if (window.lucide) lucide.createIcons();
+
+    let expandedCard = null;
+
+    function centerCardInCarousel(card, callback) {
+      const carouselRect = slider.getBoundingClientRect();
+      const cardRect = card.getBoundingClientRect();
+      const cardCenter = card.offsetLeft + (cardRect.width / 2);
+      const targetScrollLeft = cardCenter - carouselRect.width / 2;
+
+      slider.scrollTo({ left: targetScrollLeft, behavior: "smooth" });
+      if (typeof callback === 'function') {
+        setTimeout(callback, 500);
+      }
+    }
+
+    function toggleExpand(card) {
+      if (expandedCard === card) {
+        card.classList.remove("expanded", "expanding");
+        expandedCard = null;
+        return;
+      }
+      if (expandedCard) {
+        expandedCard.classList.remove("expanded", "expanding");
+        expandedCard = null;
+      }
+
+      centerCardInCarousel(card, () => {
+        card.classList.add("expanding");
+        setTimeout(() => {
+          card.classList.remove("expanding");
+          card.classList.add("expanded");
+          expandedCard = card;
+        }, 400);
+      });
+    }
+
+    document.addEventListener("keydown", e => {
+      if (e.key === "Escape" && expandedCard) {
+        expandedCard.classList.remove("expanded", "expanding");
+        expandedCard = null;
+      }
+    });
+
+    // Auto-scroll loop
+    let scrollSpeed = 1;
+    let animation;
+    function autoScroll() {
+      if (!expandedCard) {
+        slider.scrollLeft += scrollSpeed;
+        if (slider.scrollLeft >= slider.scrollWidth - slider.clientWidth) {
+          slider.scrollLeft = 0;
+        }
+      }
+      animation = requestAnimationFrame(autoScroll);
+    }
+    autoScroll();
+
+    slider.addEventListener("mouseenter", () => {
+      if (animation) {
+        cancelAnimationFrame(animation);
+        animation = null;
+      }
+    });
+    slider.addEventListener("mouseleave", () => {
+      if (!animation) {
+        autoScroll();
+      }
+    });
+  }
 
   const aiModal = document.getElementById('ai-suggester-modal');
   const openModalBtn = document.getElementById('open-ai-modal-btn');


### PR DESCRIPTION
## Summary
- rebuild the payment services slider cards dynamically with support for service imagery, details, and links
- add expansion, centering, and auto-scroll behavior to the payment services carousel
- update service card styling to support expandable overlays and hidden detail sections

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df99c8aff4833093e2943c7338f46b