### PR TITLE
Reduce integration logos and restore color

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@
   50% { border-color: #fff }
 }
 .shopify-hero {
-  height: clamp(72px, 10vw, 140px);
+  height: clamp(50px, 7vw, 98px);
   width: auto;
   object-fit: contain;
 }
@@ -404,9 +404,8 @@
   align-items: center;
 }
 .integrations-logos img {
-  max-height: 50px;
+  max-height: 35px;
   object-fit: contain;
-  filter: brightness(0) invert(1);
   transition: transform 0.3s ease;
 }
 .integrations-logos img:hover {

--- a/integrations.html
+++ b/integrations.html
@@ -430,7 +430,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://www.salesforce.com/content/dam/sfdc-docs/www/logos/logo-salesforce.svg"
-                        alt="Salesforce Logo" class="max-h-16 object-contain"
+                        alt="Salesforce Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Salesforce</p>
                 </a>
@@ -438,7 +438,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/7/79/Intuit_QuickBooks_logo.svg"
-                        alt="QuickBooks Logo" class="max-h-16 object-contain"
+                        alt="QuickBooks Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">QuickBooks</p>
                 </a>
@@ -446,7 +446,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/3/3f/HubSpot_Logo.svg" alt="HubSpot Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">HubSpot</p>
                 </a>
@@ -454,7 +454,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/79/Vend-logo.svg/512px-Vend-logo.svg.png"
-                        alt="Vend Logo" class="max-h-16 object-contain"
+                        alt="Vend Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Vend</p>
                 </a>
@@ -462,7 +462,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/en/5/53/Squarespace_Logo.svg"
-                        alt="Squarespace Logo" class="max-h-16 object-contain"
+                        alt="Squarespace Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Squarespace</p>
                 </a>
@@ -470,7 +470,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://memberpress.com/wp-content/uploads/2023/07/memberpress-by-awesome-motive-logo-flame-blue-rgb.svg"
-                        alt="MemberPress Logo" class="max-h-16 object-contain"
+                        alt="MemberPress Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">MemberPress</p>
                 </a>
@@ -478,7 +478,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2a/WooCommerce_logo.svg/512px-WooCommerce_logo.svg.png"
-                        alt="WooCommerce Logo" class="max-h-16 object-contain"
+                        alt="WooCommerce Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">WooCommerce</p>
                 </a>
@@ -486,7 +486,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/3/30/ZOHO_logo_2023.svg"
-                        alt="Zoho CRM Logo" class="max-h-16 object-contain"
+                        alt="Zoho CRM Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Zoho CRM</p>
                 </a>
@@ -494,7 +494,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/3/38/Lightspeed_-_logo.png"
-                        alt="Lightspeed Logo" class="max-h-16 object-contain"
+                        alt="Lightspeed Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Lightspeed</p>
                 </a>
@@ -502,7 +502,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://static.wixstatic.com/media/de991a_321c4356214644169542e724ef57529b~mv2.png"
-                        alt="Wix Logo" class="max-h-16 object-contain"
+                        alt="Wix Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Wix</p>
                 </a>
@@ -510,7 +510,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/e/e0/Logo_of_Keap_Company.svg"
-                        alt="Keap Logo" class="max-h-16 object-contain"
+                        alt="Keap Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Keap</p>
                 </a>
@@ -518,7 +518,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cf/Clover_logo.svg/512px-Clover_logo.svg.png"
-                        alt="Clover Logo" class="max-h-16 object-contain"
+                        alt="Clover Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Clover</p>
                 </a>
@@ -526,7 +526,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/1/17/FreshBooks_logo_%282020%29.svg"
-                        alt="FreshBooks Logo" class="max-h-16 object-contain"
+                        alt="FreshBooks Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">FreshBooks</p>
                 </a>
@@ -534,7 +534,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/55/Magento_Logo.svg/512px-Magento_Logo.svg.png"
-                        alt="Magento Logo" class="max-h-16 object-contain"
+                        alt="Magento Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Magento</p>
                 </a>
@@ -542,7 +542,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/c/c4/Bc-logo-dark.svg"
-                        alt="BigCommerce Logo" class="max-h-16 object-contain"
+                        alt="BigCommerce Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">BigCommerce</p>
                 </a>
@@ -550,7 +550,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/9/92/NCR_logo_color.svg" alt="NCR Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">NCR</p>
                 </a>
@@ -558,7 +558,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/4/41/Visa_2021.svg" alt="Visa Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Visa</p>
                 </a>
@@ -566,7 +566,7 @@
                     class="p-6 rounded-2xl bg-white/10 dark:bg-gray-800/50 backdrop-blur-lg border border-white/10 shadow-lg flex flex-col items-center justify-center aspect-square card-hover-effect"
                     target="_blank" rel="noopener">
                     <img src="https://upload.wikimedia.org/wikipedia/commons/a/a4/Mastercard_2019_logo.svg"
-                        alt="Mastercard Logo" class="max-h-16 object-contain"
+                        alt="Mastercard Logo" class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';">
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Mastercard</p>
                 </a>

--- a/integrations/index.html
+++ b/integrations/index.html
@@ -330,7 +330,7 @@
                     <img
                         src="https://www.salesforce.com/content/dam/sfdc-docs/www/logos/logo-salesforce.svg"
                         alt="Salesforce Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Salesforce</p>
@@ -344,7 +344,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/7/79/Intuit_QuickBooks_logo.svg"
                         alt="QuickBooks Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">QuickBooks</p>
@@ -358,7 +358,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/3/3f/HubSpot_Logo.svg"
                         alt="HubSpot Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">HubSpot</p>
@@ -372,7 +372,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/79/Vend-logo.svg/512px-Vend-logo.svg.png"
                         alt="Vend Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Vend</p>
@@ -386,7 +386,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/en/5/53/Squarespace_Logo.svg"
                         alt="Squarespace Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Squarespace</p>
@@ -400,7 +400,7 @@
                     <img
                         src="https://memberpress.com/wp-content/uploads/2023/07/memberpress-by-awesome-motive-logo-flame-blue-rgb.svg"
                         alt="MemberPress Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">MemberPress</p>
@@ -414,7 +414,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2a/WooCommerce_logo.svg/512px-WooCommerce_logo.svg.png"
                         alt="WooCommerce Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">WooCommerce</p>
@@ -428,7 +428,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/3/30/ZOHO_logo_2023.svg"
                         alt="Zoho CRM Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Zoho CRM</p>
@@ -442,7 +442,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/3/38/Lightspeed_-_logo.png"
                         alt="Lightspeed Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Lightspeed</p>
@@ -456,7 +456,7 @@
                     <img
                         src="https://static.wixstatic.com/media/de991a_321c4356214644169542e724ef57529b~mv2.png"
                         alt="Wix Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Wix</p>
@@ -470,7 +470,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/e/e0/Logo_of_Keap_Company.svg"
                         alt="Keap Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Keap</p>
@@ -484,7 +484,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cf/Clover_logo.svg/512px-Clover_logo.svg.png"
                         alt="Clover Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Clover</p>
@@ -498,7 +498,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/1/17/FreshBooks_logo_%282020%29.svg"
                         alt="FreshBooks Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">FreshBooks</p>
@@ -512,7 +512,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/55/Magento_Logo.svg/512px-Magento_Logo.svg.png"
                         alt="Magento Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Magento</p>
@@ -526,7 +526,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/c/c4/Bc-logo-dark.svg"
                         alt="BigCommerce Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">BigCommerce</p>
@@ -540,7 +540,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/9/92/NCR_logo_color.svg"
                         alt="NCR Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">NCR</p>
@@ -554,7 +554,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/4/41/Visa_2021.svg"
                         alt="Visa Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Visa</p>
@@ -568,7 +568,7 @@
                     <img
                         src="https://upload.wikimedia.org/wikipedia/commons/a/a4/Mastercard_2019_logo.svg"
                         alt="Mastercard Logo"
-                        class="max-h-16 object-contain"
+                        class="max-h-10 object-contain"
                         onerror="this.onerror=null;this.src='https://placehold.co/200x100/e2e8f0/e2e8f0?text=Logo';"
                     >
                     <p class="mt-4 text-sm font-medium text-slate-700 dark:text-slate-300">Mastercard</p>


### PR DESCRIPTION
## Summary
- reduce the Shopify hero image height so the logo renders roughly 30% smaller
- shrink marquee partner logos and remove the desaturating filter so they show in full color
- update integration directory cards to use a smaller max height for partner logos

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfa87a70648330822830257a910634