### PR TITLE
Improve hero and header responsiveness at default zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,19 +50,11 @@
             color: #1A1A1A;
             font-family: 'Inter', 'sans-serif';
             transition: background-color 0.3s ease, color 0.3s ease;
-            max-width: 100vw;
             overflow-x: hidden;
         }
-        
-        /* Global width constraint to prevent any elements from exceeding viewport */
-        * {
-            max-width: 100vw;
+
+        *, *::before, *::after {
             box-sizing: border-box;
-        }
-        
-        /* Reset max-width for elements that should be constrained to their containers */
-        .max-w-7xl *, .max-w-6xl *, [class*="max-w-"] * {
-            max-width: none;
         }
         .dark body {
             background-color: #1A1A1A;
@@ -99,7 +91,6 @@
         /* Slider Styles */
         .slider{
             width: 100%;
-            max-width: 100vw;
             height: 80vh; /* Fallback for browsers without aspect-ratio support */
             aspect-ratio: 16/9;
             min-height: 60vh;
@@ -107,6 +98,7 @@
             overflow: hidden;
             position: relative;
             background: #000;
+            padding: clamp(2rem, 6vw, 4rem) clamp(1.5rem, 5vw, 3rem);
         }
         
         /* For browsers that support aspect-ratio, use more flexible sizing */
@@ -137,17 +129,15 @@
         .slider .list .item img{
             width: 100%;
             height: 100%;
-            object-fit: contain;
+            object-fit: cover;
             object-position: center;
         }
         .slider .list .item .content{
             position: absolute;
-            top: 20%;
-            left: 5%; /* Further left for top-left positioning */
+            top: clamp(12%, 8vw, 20%);
+            left: clamp(1.5rem, 5vw, 6%); /* Further left for top-left positioning */
             transform: none;
-            width: 90%;
-            max-width: 700px;
-            box-sizing: border-box;
+            width: min(88%, 560px);
             color: #fff;
             text-shadow: 0 2px 8px rgba(0,0,0,0.7);
             text-align: left; /* Set text alignment to left */
@@ -155,50 +145,54 @@
 
         .slider .list .item .content .title,
         .slider .list .item .content .type{
-            font-size: 4em;
+            font-size: clamp(2.75rem, 5vw + 1rem, 4rem);
             font-weight: 700;
             line-height: 1.2;
             font-family: 'Ubuntu', sans-serif;
         }
-        
+
         .slider .list .item .content .type{
             color: #DC143C; /* brand-crimson */
-            font-size: 3em;
+            font-size: clamp(2.25rem, 4vw + 0.5rem, 3rem);
         }
 
         .slider .list .item .content .description {
             font-family: 'Inter', sans-serif;
-            font-size: 1.1rem;
+            font-size: clamp(1rem, 1vw + 0.75rem, 1.25rem);
             line-height: 1.6;
             margin-top: 1rem;
-            max-width: 600px;
+            max-width: min(520px, 85%);
         }
 
         .slider .list .item .button{
-            margin-top: 20px;
+            margin-top: clamp(1rem, 2vw, 1.75rem);
         }
 
         .thumbnail{
             position: absolute;
-            bottom: 50px;
-            right: 20px;
-            width: calc(150px * 5 + 20px * 4); /* Show 5 cards at a time as requested */
-            max-width: calc(100vw - 40px); /* Ensure it doesn't exceed viewport */
+            bottom: clamp(1.5rem, 5vw, 3.75rem);
+            right: clamp(0.75rem, 3vw, 2.5rem);
+            width: min(calc(150px * 5 + 20px * 4), 90vw); /* Show 5 cards at a time as requested */
             z-index: 100;
             display: flex;
-            gap: 20px;
+            gap: clamp(0.75rem, 2vw, 1.25rem);
             overflow: hidden;
+        }
+        @media screen and (max-width: 1440px) {
+            .thumbnail {
+                width: min(calc(150px * 4 + 20px * 3), 85vw);
+            }
         }
         .thumbnail-track {
             display: flex;
-            gap: 20px;
+            gap: clamp(0.75rem, 2vw, 1.25rem);
             /* Removed auto-scroll animation for desktop - keeping infinite cycle capability */
             will-change: transform;
             width: max-content;
         }
         .thumbnail .item{
-            width: 150px;
-            height: 220px;
+            width: clamp(120px, 11vw, 150px);
+            height: clamp(180px, 16vw, 220px);
             flex-shrink: 0;
             position: relative;
             opacity: 1;
@@ -223,8 +217,8 @@
         }
         .nextPrevArrows{
             position: absolute;
-            bottom: 120px;
-            left: 20px; /* Moved to the left side */
+            bottom: clamp(6rem, 12vw, 8rem);
+            left: clamp(1rem, 4vw, 3rem); /* Moved to the left side */
             z-index: 100;
             width: 100px;
             display: flex;
@@ -232,8 +226,8 @@
             align-items: center;
         }
         .nextPrevArrows button{
-            width: 40px;
-            height: 40px;
+            width: clamp(36px, 4vw, 44px);
+            height: clamp(36px, 4vw, 44px);
             border-radius: 50%;
             background-color: #DC143C; /* brand-crimson */
             border: none;
@@ -338,14 +332,36 @@
                 opacity: 0;
             }
         }
+        @media screen and (max-width: 992px) {
+            .slider {
+                padding: 2.5rem 1.25rem 4rem;
+                height: auto;
+                min-height: 65vh;
+            }
+            .slider .list .item .content {
+                top: 18%;
+                left: 6%;
+                width: 88%;
+            }
+            .thumbnail {
+                width: min(100%, 520px);
+                right: 50%;
+                transform: translateX(50%);
+            }
+            .nextPrevArrows {
+                bottom: 6rem;
+                left: 6%;
+            }
+        }
         @media screen and (max-width: 768px) {
             .slider {
                 height: 60vh; /* Fallback for browsers without aspect-ratio support */
                 min-height: 50vh;
                 max-height: 70vh;
                 aspect-ratio: 16/9;
+                padding: 2.5rem 1rem 2.5rem;
             }
-            
+
             /* For browsers that support aspect-ratio on mobile */
             @supports (aspect-ratio: 16/9) {
                 .slider {
@@ -353,23 +369,24 @@
                 }
             }
             
-            .slider .list .item .content { 
-                left: 5%; 
-                top: 15%;
+            .slider .list .item .content {
+                left: 5%;
+                top: 12%;
                 transform: none;
+                width: 90%;
             }
-            .slider .list .item .content .title{ font-size: 2.5em; }
-            .slider .list .item .content .type{ font-size: 2em; }
+            .slider .list .item .content .title{ font-size: clamp(2.1rem, 7vw, 2.5rem); }
+            .slider .list .item .content .type{ font-size: clamp(1.8rem, 6.5vw, 2.2rem); }
             .slider .list .item .content .description { font-size: 1rem; }
-            
+
             /* Hide cards on mobile to save real estate */
-            .thumbnail { 
+            .thumbnail {
                 display: none !important;
             }
             
             /* Keep navigation arrows visible and functional on mobile */
-            .nextPrevArrows { 
-                bottom: 30px; 
+            .nextPrevArrows {
+                bottom: 30px;
                 left: 20px; /* Also moved to left on mobile */
                 display: flex;
             }
@@ -379,7 +396,64 @@
                 display: none;
             }
         }
-            
+
+        /* Header responsive refinements */
+        .header-logo {
+            width: clamp(180px, 16vw, 260px);
+        }
+
+        .header-nav {
+            transition: gap 0.2s ease;
+        }
+
+        .header-actions {
+            transition: gap 0.2s ease;
+        }
+
+        .header-action {
+            transition: padding 0.2s ease, font-size 0.2s ease;
+        }
+
+        @media screen and (max-width: 1280px) {
+            .header-nav {
+                gap: 1.5rem;
+                font-size: 0.95rem;
+            }
+            .header-actions {
+                gap: 0.75rem;
+            }
+            .header-action {
+                padding-left: 0.9rem;
+                padding-right: 0.9rem;
+                font-size: 0.9rem;
+            }
+            .header-logo {
+                width: clamp(150px, 18vw, 240px);
+            }
+        }
+
+        @media screen and (max-width: 1100px) {
+            .header-nav {
+                gap: 1.1rem;
+                font-size: 0.9rem;
+            }
+            .header-action--support,
+            .header-action--theme {
+                display: none;
+            }
+            .header-action {
+                padding-left: 0.8rem;
+                padding-right: 0.8rem;
+            }
+        }
+
+        @media screen and (max-width: 1023px) {
+            .header-nav,
+            .header-actions {
+                display: none !important;
+            }
+        }
+
         /* Integrations marquee animation */
         @keyframes marquee {
           from { transform: translateX(0); }
@@ -437,36 +511,36 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between py-4">
                 <a href="/index.html" class="flex items-center gap-3">
-                    <div class="w-[190px] md:w-[260px]" data-mh-logo-header></div>
+                    <div class="header-logo" data-mh-logo-header></div>
                     <span class="sr-only">MerchantHaus homepage</span>
                 </a>
-                <nav class="hidden md:flex items-center gap-8 text-sm font-medium text-brand-dark/80">
+                <nav class="hidden md:flex items-center gap-8 text-sm font-medium text-brand-dark/80 header-nav">
                     <a class="hover:text-brand-crimson transition" href="#platform">Platform</a>
                     <a class="hover:text-brand-crimson transition" href="#solutions">Solutions</a>
                     <a class="hover:text-brand-crimson transition" href="#industries">Industries</a>
                     <a class="hover:text-brand-crimson transition" href="/faq.html">Developers</a>
                     <a class="hover:text-brand-crimson transition" href="/compliance.html">Pricing</a>
                 </nav>
-                <div class="hidden md:flex items-center gap-3">
-                    <button type="button" class="js-support inline-flex items-center gap-2 rounded-full border border-brand-crimson/20 px-4 py-2 text-sm font-semibold text-brand-crimson transition hover:bg-brand-crimson hover:text-white" data-cta="contact-support" data-cta-location="header">
+                <div class="hidden md:flex items-center gap-3 header-actions">
+                    <button type="button" class="js-support inline-flex items-center gap-2 rounded-full border border-brand-crimson/20 px-4 py-2 text-sm font-semibold text-brand-crimson transition hover:bg-brand-crimson hover:text-white header-action header-action--support" data-cta="contact-support" data-cta-location="header">
                         <i data-lucide="life-buoy" class="h-4 w-4"></i>
                         Support
                     </button>
-                    <button type="button" class="js-cta inline-flex items-center gap-2 rounded-full border-2 border-brand-dark px-5 py-2 text-sm font-semibold text-brand-dark transition hover:bg-brand-crimson hover:text-white hover:border-brand-crimson">
+                    <button type="button" class="js-cta inline-flex items-center gap-2 rounded-full border-2 border-brand-dark px-5 py-2 text-sm font-semibold text-brand-dark transition hover:bg-brand-crimson hover:text-white hover:border-brand-crimson header-action">
                         <i data-lucide="calendar" class="h-4 w-4"></i>
                         Contact Us
                     </button>
-                    <button id="theme-toggle" type="button" class="inline-flex items-center gap-2 rounded-full border border-brand-dark/10 px-4 py-2 text-sm font-semibold text-brand-dark transition hover:border-brand-crimson hover:text-brand-crimson">
+                    <button id="theme-toggle" type="button" class="inline-flex items-center gap-2 rounded-full border border-brand-dark/10 px-4 py-2 text-sm font-semibold text-brand-dark transition hover:border-brand-crimson hover:text-brand-crimson header-action header-action--theme">
                         <i data-lucide="sun" class="h-4 w-4 dark:hidden"></i>
                         <i data-lucide="moon" class="h-4 w-4 hidden dark:block"></i>
                         Theme
                     </button>
-                    <button type="button" class="js-signup-cta inline-flex items-center gap-2 rounded-full border border-brand-dark/10 px-4 py-2 text-sm font-semibold text-brand-dark transition hover:border-brand-crimson hover:text-brand-crimson">
+                    <button type="button" class="js-signup-cta inline-flex items-center gap-2 rounded-full border border-brand-dark/10 px-4 py-2 text-sm font-semibold text-brand-dark transition hover:border-brand-crimson hover:text-brand-crimson header-action">
                         <i data-lucide="sparkles" class="h-4 w-4"></i>
                         Create account
                     </button>
                 </div>
-                <div class="md:hidden flex items-center gap-3">
+                <div class="flex items-center gap-3 lg:hidden">
                     <button type="button" class="js-cta inline-flex items-center gap-2 rounded-full bg-brand-crimson px-4 py-2 text-sm font-semibold text-white shadow-sm">
                         Contact
                     </button>
@@ -477,7 +551,7 @@
                 </div>
             </div>
         </div>
-        <div id="mobile-menu" class="md:hidden hidden border-t border-brand-silver/20 bg-white dark:bg-brand-dark">
+        <div id="mobile-menu" class="lg:hidden hidden border-t border-brand-silver/20 bg-white dark:bg-brand-dark">
             <div class="px-4 py-6 space-y-4 text-sm text-brand-dark/85">
                 <a class="block rounded-lg border border-brand-silver/30 px-4 py-2 hover:border-brand-crimson hover:text-brand-crimson transition" href="#platform">Platform</a>
                 <a class="block rounded-lg border border-brand-silver/30 px-4 py-2 hover:border-brand-crimson hover:text-brand-crimson transition" href="#solutions">Solutions</a>


### PR DESCRIPTION
## Summary
- remove rigid global width rules and add fluid padding, typography, and card sizing for the hero slider so it scales correctly at 100% zoom
- add responsive header utility classes to shrink or hide actions and navigation before switching to the mobile menu
- tweak thumbnail carousel breakpoints so fewer cards show on mid-sized screens and prevent overlap with hero copy

## Testing
- visual verification in Playwright at 1920px, 1536px, 1400px, 1280px, and 1000px widths


------
https://chatgpt.com/codex/tasks/task_b_68eafaf523cc83298873a39d432648ae