### PR TITLE
Revamp hero section layout and remove chat widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,8 +154,13 @@
             border: 0;
         }
 
-        .hero-layout {
-            gap: 2.5rem;
+        .hero-content-grid {
+            display: grid;
+            gap: 3rem;
+        }
+
+        .hero-text-block {
+            max-width: 38rem;
         }
 
         .hero-overlay {
@@ -164,12 +169,180 @@
         }
 
         .hero-heading {
-            font-size: clamp(1.75rem, 4vw + 0.5rem, 3.25rem);
-            line-height: 1.15;
+            font-size: clamp(2.25rem, 4.5vw + 0.5rem, 3.75rem);
+            line-height: 1.08;
         }
 
         .hero-subheading {
             font-size: clamp(1.25rem, 3vw + 0.25rem, 2.5rem);
+        }
+
+        .hero-kicker {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.35rem 0.85rem;
+            border-radius: 9999px;
+            background: linear-gradient(120deg, rgba(92, 221, 173, 0.18), rgba(220, 20, 60, 0.18));
+            border: 1px solid rgba(255, 255, 255, 0.25);
+            font-size: 0.875rem;
+            font-weight: 600;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: #5CDDAD;
+        }
+
+        .hero-cta-group {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            align-items: center;
+        }
+
+        .hero-secondary-cta {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.75rem 1.5rem;
+            border-radius: 9999px;
+            border: 1px solid rgba(255, 255, 255, 0.45);
+            color: #F5F7FA;
+            font-weight: 600;
+            transition: border-color 250ms ease, background-color 250ms ease, color 250ms ease;
+        }
+
+        .hero-secondary-cta:hover,
+        .hero-secondary-cta:focus-visible {
+            color: #111827;
+            border-color: rgba(92, 221, 173, 0.8);
+            background-color: rgba(92, 221, 173, 0.9);
+        }
+
+        .hero-metrics {
+            display: grid;
+            gap: 1.25rem;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        }
+
+        .hero-metric {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+            padding-left: 0.65rem;
+            border-left: 2px solid rgba(255, 255, 255, 0.25);
+        }
+
+        .hero-metric strong {
+            font-size: 1.1rem;
+            color: #5CDDAD;
+        }
+
+        .hero-highlight-card {
+            position: relative;
+            overflow: hidden;
+            border-radius: 1.5rem;
+            padding: clamp(1.75rem, 2vw + 1rem, 2.5rem);
+            background: linear-gradient(165deg, rgba(15, 23, 42, 0.7), rgba(12, 74, 110, 0.35));
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            backdrop-filter: blur(12px);
+            box-shadow: 0 32px 120px rgba(8, 47, 73, 0.35);
+        }
+
+        .hero-highlight-card::before {
+            content: "";
+            position: absolute;
+            inset: -40% 30% auto -30%;
+            height: 200%;
+            background: radial-gradient(circle at top, rgba(92, 221, 173, 0.22), transparent 60%);
+            pointer-events: none;
+            opacity: 0.8;
+        }
+
+        .hero-highlight-card::after {
+            content: "";
+            position: absolute;
+            inset: auto -20% -50% 20%;
+            height: 200%;
+            background: radial-gradient(circle at bottom, rgba(220, 20, 60, 0.18), transparent 60%);
+            pointer-events: none;
+        }
+
+        .hero-highlight-card > * {
+            position: relative;
+            z-index: 1;
+        }
+
+        .hero-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.4rem 0.9rem;
+            font-size: 0.75rem;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            border-radius: 9999px;
+            background: rgba(15, 118, 110, 0.25);
+            border: 1px solid rgba(255, 255, 255, 0.25);
+            color: #F8FAFC;
+        }
+
+        .hero-highlight-title {
+            font-size: clamp(1.35rem, 2.8vw, 2rem);
+            font-weight: 700;
+            color: #F8FAFC;
+        }
+
+        .hero-feature-list {
+            margin-top: 1.5rem;
+            display: grid;
+            gap: 1rem;
+        }
+
+        .hero-feature-item {
+            display: flex;
+            align-items: flex-start;
+            gap: 0.75rem;
+        }
+
+        .hero-feature-item i {
+            color: #5CDDAD;
+        }
+
+        .hero-feature-item span {
+            color: #E2E8F0;
+            line-height: 1.5;
+        }
+
+        .hero-animate {
+            opacity: 0;
+            transform: translateY(24px);
+            animation: heroFadeUp 0.85s forwards;
+            animation-delay: var(--hero-delay, 0s);
+        }
+
+        .hero-highlight-card.hero-animate {
+            animation-name: heroFadeUp, heroFloat;
+            animation-duration: 0.85s, 8s;
+            animation-delay: var(--hero-delay, 0s), calc(var(--hero-delay, 0s) + 0.85s);
+            animation-fill-mode: forwards, both;
+            animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1), ease-in-out;
+            animation-iteration-count: 1, infinite;
+        }
+
+        @keyframes heroFadeUp {
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        @keyframes heroFloat {
+            0%, 100% {
+                transform: translateY(0);
+            }
+            50% {
+                transform: translateY(-12px);
+            }
         }
 
         .section-heading {
@@ -207,41 +380,38 @@
             padding-bottom: 1rem;
         }
 
+        @media (min-width: 768px) {
+            .hero-content-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+                align-items: center;
+            }
+        }
+
         @media (max-width: 767px) {
-            .hero-layout {
-                gap: 2rem;
-            }
-
-            .hero-text {
+            .hero-text-block {
                 text-align: center;
-            }
-
-            .hero-text p {
-                text-align: center;
-            }
-
-            .hero-chat-card {
-                width: 100%;
                 margin: 0 auto;
-                padding: 1.25rem;
-                background-color: rgba(15, 23, 42, 0.35);
-                border-radius: 1.5rem;
-                backdrop-filter: blur(6px);
             }
 
-            .hero-chat-card .field {
-                font-size: 1rem;
-                padding-top: 0.85rem;
-                padding-bottom: 0.85rem;
+            .hero-cta-group {
+                justify-content: center;
             }
 
-            .hero-chat-card button {
-                transform: scale(0.95);
+            .hero-highlight-card {
+                margin: 0 auto;
+                max-width: 28rem;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .hero-animate {
+                animation: none;
+                opacity: 1;
+                transform: none;
             }
 
-            #faq-answer {
-                max-height: 240px;
-                font-size: 0.95rem;
+            .hero-highlight-card.hero-animate {
+                animation: none;
             }
         }
     </style>
@@ -469,9 +639,6 @@
 .service-cell h3, .service-cell p { opacity: 0; transform: translateY(10px); transition: opacity 0.4s ease-out, transform 0.4s ease-out; }
 .service-cell.is-visible h3 { opacity: 1; transform: translateY(0); transition-delay: 0.2s; }
 .service-cell.is-visible p { opacity: 1; transform: translateY(0); transition-delay: 0.3s; }
-#faq-answer p { margin: 0 0 0.75rem; }
-#faq-answer p:last-child { margin-bottom: 0; }
-#faq-answer ul { margin: 0; }
 .hero-bg-container::before { content: ''; position: absolute; inset: 0; background-image: url('/public/assets/images/hero.webp'); background-size: 100%; background-position: center; background-repeat: no-repeat; animation: kenBurns 20s ease-in-out infinite alternate; z-index: -20; }
 @keyframes kenBurns { 0% { transform: scale(1) rotate(0deg); background-position: center; } 100% { transform: scale(1.1) rotate(1deg); background-position: top left; } }
 @media (prefers-reduced-motion: reduce) { .marquee-track { animation: none !important; } }
@@ -739,48 +906,75 @@
     <!-- Dark overlay to improve contrast -->
     <div class="absolute inset-0 bg-black/60 -z-10"></div>
     <div class="max-w-7xl mx-auto px-4 pt-16 sm:pt-24 md:pt-32 pb-24 md:pb-32">
-      <div class="flex flex-col-reverse hero-layout md:grid md:grid-cols-2 md:gap-10 items-center">
-        <div class="space-y-6 hero-text">
-          <h1 class="hero-heading tracking-tight text-white uppercase font-ubuntu">
-            Payment freedom that powers your growth
+      <div class="hero-content-grid">
+        <div class="hero-text-block space-y-6">
+          <span class="hero-kicker hero-animate" style="--hero-delay: 0.1s">
+            <i data-lucide="sparkles" class="h-4 w-4"></i>
+            Merchant Payments OS
+          </span>
+          <h1 class="hero-heading tracking-tight text-white uppercase font-ubuntu hero-animate" style="--hero-delay: 0.2s">
+            Payment freedom that <span class="text-brand-teal">powers your growth</span>
           </h1>
-          <h2 class="hero-subheading text-brand-teal font-ubuntu font-bold">
+          <h2 class="hero-subheading text-brand-teal font-ubuntu font-bold hero-animate" style="--hero-delay: 0.3s">
             Speed. Security. Scale.
           </h2>
-          <p class="text-lg text-gray-200 dark:text-slate-300 font-inter text-left md:text-left" style="font-weight:100">
+          <p class="text-lg text-gray-200 dark:text-slate-300 font-inter hero-animate" style="--hero-delay: 0.4s; font-weight:100">
             Create your business profile in minutes and begin accepting cards, ACH, and secure pay links anywhere—online, in‑store, or on the go. Reduce your costs, onboard quickly, monitor performance in real time, and safeguard every transaction with next‑generation fraud and chargeback protection.
           </p>
-        </div>
-        <!-- Retain existing chat card for FAQs and actions -->
-        <div class="relative p-4 hero-chat-card">
-          <div class="w-full space-y-4 relative z-10">
-            <div class="relative">
-              <input
-                type="text"
-                id="faq-question"
-                placeholder="Ask about pricing, features..."
-                class="field w-full p-4 pr-12 text-lg rounded-full bg-white/20 dark:bg-slate-900/30 border border-slate-300/50 dark:border-slate-700/50 text-white placeholder-slate-300 focus:ring-2 focus:ring-brand-crimson focus:border-transparent transition-all"
-              />
-              <button
-                id="ask-faq"
-                class="absolute top-1/2 right-2 -translate-y-1/2 p-2 rounded-full bg-brand-crimson text-white hover:bg-brand-crimson transition-colors"
-              >
-                <i data-lucide="arrow-up" class="h-5 w-5"></i>
-              </button>
-            </div>
-            <div id="hero-actions" class="flex flex-wrap items-center justify-center gap-3">
-              <button
-                class="js-signup-cta bg-transparent hover:bg-brand-crimson text-brand-crimson hover:text-white border border-brand-crimson px-4 py-2 rounded-full text-sm font-semibold transition-colors duration-300"
-              >
-                Get Started
-              </button>
-            </div>
-            <div
-              id="faq-answer"
-              class="mt-6 p-4 text-left rounded-lg bg-white/90 dark:bg-slate-900/90 border border-slate-200 dark:border-slate-800 text-slate-800 dark:text-slate-200"
-            ></div>
-            <div id="faq-answer" class="mt-6 p-4 text-left rounded-lg bg-white/90 dark:bg-slate-900/90 border border-slate-300 dark:border-slate-800 text-slate-900 dark:text-slate-200"></div>
+          <div class="hero-cta-group hero-animate" style="--hero-delay: 0.5s">
+            <button
+              class="js-signup-cta inline-flex items-center justify-center rounded-full bg-brand-crimson px-6 py-3 font-semibold text-white transition-transform duration-300 hover:scale-[1.02] hover:bg-brand-crimson/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-brand-crimson"
+            >
+              Get Started
+            </button>
+            <a
+              class="hero-secondary-cta"
+              href="#payments"
+            >
+              <i data-lucide="arrow-right" class="h-4 w-4"></i>
+              Explore Platform
+            </a>
           </div>
+          <div class="hero-metrics hero-animate" style="--hero-delay: 0.65s">
+            <div class="hero-metric">
+              <strong>24hr</strong>
+              <span class="text-sm text-slate-200">Average onboarding turnaround</span>
+            </div>
+            <div class="hero-metric">
+              <strong>40+</strong>
+              <span class="text-sm text-slate-200">Payment integrations ready to launch</span>
+            </div>
+            <div class="hero-metric">
+              <strong>99.99%</strong>
+              <span class="text-sm text-slate-200">Uptime across every channel</span>
+            </div>
+          </div>
+        </div>
+        <div class="hero-highlight-card hero-animate" style="--hero-delay: 0.4s">
+          <span class="hero-badge">
+            <i data-lucide="shield-check" class="h-4 w-4"></i>
+            Built for bold merchants
+          </span>
+          <h3 class="hero-highlight-title mt-4">
+            Launch unified payments with enterprise-grade safeguards.
+          </h3>
+          <p class="mt-3 text-slate-200/90 leading-relaxed">
+            MerchantHaus orchestrates every payment touchpoint with advanced fraud controls, intelligent routing, and real-time analytics so you can scale without friction.
+          </p>
+          <ul class="hero-feature-list">
+            <li class="hero-feature-item">
+              <i data-lucide="zap" class="h-5 w-5"></i>
+              <span>Instant approvals and fast funding keep revenue flowing.</span>
+            </li>
+            <li class="hero-feature-item">
+              <i data-lucide="lock" class="h-5 w-5"></i>
+              <span>Adaptive fraud defense, tokenization, and Level 3 optimization.</span>
+            </li>
+            <li class="hero-feature-item">
+              <i data-lucide="bar-chart-3" class="h-5 w-5"></i>
+              <span>Command-center insights with configurable dashboards and alerts.</span>
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -1375,118 +1569,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }, { threshold: 0.8 });
   document.querySelectorAll('.animate-on-scroll').forEach(el => headingObserver.observe(el));
 
-  const askFaqBtn = document.getElementById('ask-faq');
-  const faqQuestionInput = document.getElementById('faq-question');
-  const faqAnswerContainer = document.getElementById('faq-answer');
-
-  const createFaqInlineNodes = (text) => {
-    const fragment = document.createDocumentFragment();
-    if (!text) return fragment;
-    const boldRegex = /\*\*(.*?)\*\*/g;
-    let lastIndex = 0;
-    let match;
-    while ((match = boldRegex.exec(text)) !== null) {
-      if (match.index > lastIndex) {
-        fragment.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
-      }
-      const strong = document.createElement('strong');
-      strong.textContent = match[1];
-      fragment.appendChild(strong);
-      lastIndex = boldRegex.lastIndex;
-    }
-    if (lastIndex < text.length) {
-      fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
-    }
-    return fragment;
-  };
-
-  const sanitizeFaqReply = (reply) => {
-    if (typeof reply !== 'string') return [];
-    const lines = reply.split(/\r?\n/);
-    const nodes = [];
-    let listEl = null;
-    let paragraphBuffer = [];
-
-    const flushList = () => {
-      if (listEl) {
-        nodes.push(listEl);
-        listEl = null;
-      }
-    };
-
-    const flushParagraph = () => {
-      if (!paragraphBuffer.length) return;
-      const paragraph = document.createElement('p');
-      paragraph.appendChild(createFaqInlineNodes(paragraphBuffer.join(' ')));
-      nodes.push(paragraph);
-      paragraphBuffer = [];
-    };
-
-    lines.forEach((line) => {
-      const trimmed = line.trim();
-      if (!trimmed) {
-        flushParagraph();
-        flushList();
-        return;
-      }
-      const bulletMatch = trimmed.match(/^[-*] (.+)$/);
-      if (bulletMatch) {
-        flushParagraph();
-        if (!listEl) {
-          listEl = document.createElement('ul');
-          listEl.className = 'list-disc pl-5 space-y-2';
-        }
-        const li = document.createElement('li');
-        li.appendChild(createFaqInlineNodes(bulletMatch[1].trim()));
-        listEl.appendChild(li);
-      } else {
-        flushList();
-        paragraphBuffer.push(line.trim());
-      }
-    });
-
-    flushParagraph();
-    flushList();
-    return nodes;
-  };
-
-  const handleFaqSubmit = async () => {
-    const question = faqQuestionInput.value.trim();
-    if (!question) return;
-    faqAnswerContainer.classList.remove('hidden');
-    askFaqBtn.disabled = true;
-    askFaqBtn.innerHTML = '<span class="loader"></span>';
-    faqAnswerContainer.textContent = 'Thinking...';
-    try {
-      const response = await fetch('/.netlify/functions/gemini-chat', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: question, history: [] })
-      });
-      if (!response.ok) throw new Error('API request failed');
-      const result = await response.json();
-      if (result.reply) {
-        const sanitizedNodes = sanitizeFaqReply(result.reply);
-        if (sanitizedNodes.length) {
-          faqAnswerContainer.replaceChildren(...sanitizedNodes);
-        } else {
-          faqAnswerContainer.textContent = 'Sorry, I could not find an answer to your question.';
-        }
-      } else {
-        faqAnswerContainer.textContent = 'Sorry, I could not find an answer to your question.';
-      }
-    } catch (err) {
-      console.error('Error fetching AI response:', err);
-      faqAnswerContainer.textContent = 'Sorry, something went wrong. Please try again later.';
-    } finally {
-      askFaqBtn.disabled = false;
-      askFaqBtn.innerHTML = '<i data-lucide="arrow-up" class="h-5 w-5"></i>';
-      if (window.lucide) lucide.createIcons();
-    }
-  };
-  askFaqBtn.addEventListener('click', handleFaqSubmit);
-  faqQuestionInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') handleFaqSubmit(); });
-
   // --- APPLICATION FORM LOGIC ---
   const applyForm = document.getElementById('apply-form');
   if (applyForm) {
@@ -1943,101 +2025,5 @@ document.addEventListener('DOMContentLoaded', () => {
     </script>
     <!-- ================= GLOBAL LAYOUT SCRIPTS END ================= -->
 
-<!-- ================= CHATBOT INTEGRATION SECTION START ================= -->
-<!-- Third-party ChatBot embed and custom styling for FAQ assistant -->
-<!-- Start of ChatBot (www.chatbot.com) code -->
-<script>
-  window.__ow = window.__ow || {};
-  window.__ow.organizationId = "ded96f09-612d-4fa3-b3e8-014830167318";
-  window.__ow.template_id = "200f2913-f66f-4b3a-aa4c-349b6e62113f";
-  window.__ow.integration_name = "manual_settings";
-  window.__ow.product_name = "chatbot";   
-  ;(function(n,t,c){function i(n){return e._h?e._h.apply(null,n):e._q.push(n)}var e={_q:[],_h:null,_v:"2.0",on:function(){i(["on",c.call(arguments)])},once:function(){i(["once",c.call(arguments)])},off:function(){i(["off",c.call(arguments)])},get:function(){if(!e._h)throw new Error("[OpenWidget] You can't use getters before load.");return i(["get",c.call(arguments)])},call:function(){i(["call",c.call(arguments)])},init:function(){var n=t.createElement("script");n.async=!0,n.type="text/javascript",n.src="https://cdn.openwidget.com/openwidget.js",t.head.appendChild(n)}};!n.__ow.asyncInit&&e.init(),n.OpenWidget=n.OpenWidget||e}(window,document,[].slice))
-</script>
-<noscript>You need to <a href="https://www.chatbot.com/help/chat-widget/enable-javascript-in-your-browser/" rel="noopener nofollow">enable JavaScript</a> in order to use the AI chatbot tool powered by <a href="https://www.chatbot.com/" rel="noopener nofollow" target="_blank">ChatBot</a></noscript>
-<!-- End of ChatBot code -->
-<style>
-  #faq-answer {
-    max-height: 320px;
-    overflow-y: auto;
-    padding: 1rem;
-    background: rgba(248, 250, 252, 0.9);
-    border-radius: 0.5rem;
-    margin-bottom: 1rem;
-  }
-  .dark #faq-answer {
-    background: rgba(15, 23, 42, 0.9);
-  }
-  .chat-user {
-    background: #dc143c;
-    color: #fff;
-    padding: 0.5rem 1rem;
-    border-radius: 1rem 1rem 0 1rem;
-    margin: 0.5rem 0 0.5rem auto;
-    max-width: 70%;
-    text-align: right;
-    float: right;
-    clear: both;
-    box-shadow: 0 2px 8px rgba(220,20,60,0.08);
-  }
-  .chat-bot {
-    background: #475569;
-    color: #f1f5f9;
-    padding: 0.5rem 1rem;
-    border-radius: 1rem 1rem 1rem 0;
-    margin: 0.5rem auto 0.5rem 0;
-    max-width: 70%;
-    text-align: left;
-    float: left;
-    clear: both;
-    box-shadow: 0 2px 8px rgba(71,85,105,0.08);
-  }
-</style>
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  const input = document.getElementById('faq-question');
-  const sendBtn = document.getElementById('ask-faq');
-  const answerBox = document.getElementById('faq-answer');
-
-  function appendMessage(text, sender) {
-    const div = document.createElement('div');
-    div.className = sender === 'user' ? 'chat-user' : 'chat-bot';
-    div.textContent = text;
-    answerBox.appendChild(div);
-    answerBox.scrollTop = answerBox.scrollHeight;
-  }
-
-  function sendMessage() {
-    const text = input.value.trim();
-    if (!text) return;
-    appendMessage(text, 'user');
-    input.value = '';
-    if (!window.ChatBot || typeof window.ChatBot.call !== 'function') {
-      console.warn('ChatBot.com integration not found.');
-      appendMessage('ChatBot integration not available.', 'bot');
-      return;
-    }
-    window.ChatBot.call('send', { message: text });
-  }
-
-  input.addEventListener('keydown', function(e) {
-    if (e.key === 'Enter') {
-      sendMessage();
-    }
-  });
-  sendBtn.addEventListener('click', sendMessage);
-
-  if (window.ChatBot && typeof window.ChatBot.on === 'function') {
-    window.ChatBot.on('message', function(data) {
-      if (data && data.message) {
-        appendMessage(data.message, 'bot');
-      }
-    });
-  } else {
-    console.warn('ChatBot.com integration not found.');
-  }
-});
-</script>
-<!-- ================= CHATBOT INTEGRATION SECTION END ================= -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the hero chat widget with a text-forward layout featuring animated headline, CTA buttons, and supporting metrics
- introduce a glassmorphism highlight card with feature list and motion while reusing the existing animated background
- remove the unused FAQ chatbot scripts and styles tied to the previous chat input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68eb9e37160c8329b29df929c6135c9a